### PR TITLE
fix: ensure min notional and candidate listing

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -384,7 +384,8 @@ def _log_audit(self, event: str, sym: str, detail: str):
                 self._try_fill_sim_orders(snapshot)
 
                 open_count = len(snapshot.get("open_orders", []))
-                candidates = self._find_candidates(snapshot)(snapshot)
+                # Determina los pares candidatos usando el snapshot actual
+                candidates = self._find_candidates(snapshot)
 
                 do_call = False
                 if not self._first_call_done and ((snapshot.get('pairs') and len(snapshot.get('pairs'))>0) or open_count):

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -273,7 +273,10 @@ class BinanceExchange:
         return float(usd) / (pbtc or 1.0)
 
     def global_min_notional_usd(self) -> float:
-        """Devuelve el mínimo notional (USDT) más bajo que exige Binance entre mercados spot activos con quote estable."""
+        """Devuelve el mínimo notional (USDT) más bajo que exige Binance entre mercados spot activos con quote estable.
+
+        Se añade un margen de 0.1 USDT para asegurar que las órdenes
+        cumplen con el mínimo requerido por Binance."""
         self.load_markets()
         min_usd = None
         for m in self.exchange.markets.values():
@@ -296,4 +299,4 @@ class BinanceExchange:
                 min_usd = val if (min_usd is None or val < min_usd) else min_usd
             except Exception:
                 continue
-        return float(min_usd if min_usd is not None else 5.0)
+        return float((min_usd if min_usd is not None else 5.0) + 0.1)


### PR DESCRIPTION
## Summary
- add 0.1 USDT safety margin to Binance global minimum notional calculation
- fix candidate list computation so market tab displays pairs

## Testing
- `python -m py_compile exchange_utils.py engine.py`


------
https://chatgpt.com/codex/tasks/task_e_689e8744464483289d8c9417f5fa0c99