### PR TITLE
Fix leftover merge conflict in Binance minimum notional lookup

### DIFF
--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -277,8 +277,6 @@ class BinanceExchange:
 
         Se añade un margen de 0.1 USDT para asegurar que las órdenes
         cumplen con el mínimo requerido por Binance."""
-<<<<<< codex/fix-minimum-allowed-amount-for-binance-v02fj6
-
         default = 5.0
         buffer = 0.1
 
@@ -299,10 +297,6 @@ class BinanceExchange:
         except Exception:
             # Si la carga de mercados falla devolvemos el fallback seguro
             return float(default + buffer)
-
-=======
-        self.load_markets()
->>>>>> main
         min_usd = None
         for m in self.exchange.markets.values():
             try:
@@ -328,9 +322,4 @@ class BinanceExchange:
                 min_usd = val if (min_usd is None or val < min_usd) else min_usd
             except Exception:
                 continue
-<<<<<< codex/fix-minimum-allowed-amount-for-binance-v02fj6
-
         return float((min_usd if min_usd is not None else default) + buffer)
-=======
-        return float((min_usd if min_usd is not None else 5.0) + 0.1)
->>>>>> main


### PR DESCRIPTION
## Summary
- remove unresolved merge markers in `global_min_notional_usd`
- fallback to exchange info when retrieving Binance minimum notional

## Testing
- `python -m py_compile exchange_utils.py`
- `python main.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689e9287e66c8328b70127d3eb337a44