### PR TITLE
Corrige mínimo Binance, candidatos y saludo al LLM

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -126,8 +126,9 @@ class Engine(threading.Thread):
         cands: List[Dict[str, Any]] = []
         for p in snapshot.get("pairs", []):
             mid = float(p.get("mid") or p.get("price_last") or 0.0)
-            tick_pct = (1e-8 / mid * 100.0) if mid else 0.0
-            p["tick_pct_sat"] = tick_pct
+            tick_sz = float(p.get("tick_size") or 1e-8)
+            tick_pct = (tick_sz / mid * 100.0) if mid else 0.0
+            p["tick_pct"] = tick_pct
             if tick_pct > thr_pct:
                 cands.append(p)
         return cands
@@ -406,6 +407,12 @@ def _log_audit(self, event: str, sym: str, detail: str):
 
                 actions: List[Dict[str, Any]] = []
                 if do_call:
+                    try:
+                        greet_msg = self.llm.greet("hola")
+                        if greet_msg:
+                            self.ui_log(f"[LLM] {greet_msg}")
+                    except Exception:
+                        pass
                     llm_out = self.llm.propose_actions({
                         **snapshot,
                         "config": {**snapshot["config"], "max_actions_per_cycle": self.cfg.llm_max_actions_per_cycle},

--- a/llm_client.py
+++ b/llm_client.py
@@ -44,6 +44,20 @@ class LLMClient:
                 pass
         return self._propose_dummy(snapshot)
 
+    def greet(self, message: str = "hola") -> str:
+        if self._openai:
+            try:
+                resp = self._openai.chat.completions.create(
+                    model=self.model,
+                    messages=[{"role": "user", "content": message}],
+                    temperature=self.temp_op,
+                    timeout=20,
+                )
+                return resp.choices[0].message.content or ""
+            except Exception:
+                return ""
+        return ""
+
     # -------------------- OpenAI --------------------
     def _propose_openai(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
         client = self._openai

--- a/ui_app.py
+++ b/ui_app.py
@@ -504,7 +504,7 @@ class App(tb.Window):
         self.lbl_ws.configure(text=f"WS: {gs.get('latency_ws_ms',0):.0f} ms")
 
         # Tablas
-        self._refresh_market_table(snap.get("pairs", []))
+        self._refresh_market_table(snap.get("candidates") or snap.get("pairs", []))
         self._refresh_open_orders(snap.get("open_orders", []))
         self._refresh_closed_orders(snap.get("closed_orders", []))
 


### PR DESCRIPTION
## Summary
- Ajusta el cálculo del mínimo notional global añadiendo solo 0.01 USDT de margen.
- Usa tick size real de cada par para detectar candidatos y mostrarlos en la tabla.
- Llama al LLM con un "hola" al iniciar y en cada intervalo configurado.

## Testing
- `python -m py_compile exchange_utils.py engine.py ui_app.py llm_client.py`


------
https://chatgpt.com/codex/tasks/task_e_689e94c16b5c8328ae6ac7c79b4004f0