### PR TITLE
Corrige mínimo BTC, candidatos y guarda APIs

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -35,6 +35,7 @@ class Engine(threading.Thread):
         self._last_reasons: List[str] = []
         self._first_call_done: bool = False
         self._last_auto_ts: float = 0.0
+        self._greet_sent: bool = False
 
         os.makedirs(self.cfg.log_dir, exist_ok=True)
         self._audit_file = os.path.join(self.cfg.log_dir, "audit.csv")
@@ -126,8 +127,9 @@ class Engine(threading.Thread):
         cands: List[Dict[str, Any]] = []
         for p in snapshot.get("pairs", []):
             mid = float(p.get("mid") or p.get("price_last") or 0.0)
-            tick_pct = (1e-8 / mid * 100.0) if mid else 0.0
-            p["tick_pct_sat"] = tick_pct
+            tick = float(p.get("tick_size") or 1e-8)
+            tick_pct = (tick / mid * 100.0) if mid else 0.0
+            p["tick_pct"] = tick_pct
             if tick_pct > thr_pct:
                 cands.append(p)
         return cands
@@ -377,11 +379,11 @@ def _log_audit(self, event: str, sym: str, detail: str):
         while not self.is_stopped():
             try:
                 snapshot = self.build_snapshot()
+                self.ui_push_snapshot(snapshot)
                 self._try_fill_sim_orders(snapshot)
 
                 open_count = len(snapshot.get("open_orders", []))
-                # Determina los pares candidatos usando el snapshot actual
-                candidates = self._find_candidates(snapshot)
+                candidates = snapshot.get("candidates", []) or self._find_candidates(snapshot)
 
                 do_call = False
                 if not self._first_call_done and ((snapshot.get('pairs') and len(snapshot.get('pairs'))>0) or open_count):
@@ -406,11 +408,19 @@ def _log_audit(self, event: str, sym: str, detail: str):
 
                 actions: List[Dict[str, Any]] = []
                 if do_call:
-                    llm_out = self.llm.propose_actions({
-                        **snapshot,
-                        "config": {**snapshot["config"], "max_actions_per_cycle": self.cfg.llm_max_actions_per_cycle},
-                    })
-                    actions = llm_out.get("actions", [])
+                    try:
+                        greet_msg = self.llm.greet("hola")
+                        if greet_msg:
+                            self.ui_log(f"[LLM] {greet_msg}")
+                    except Exception:
+                        pass
+                    if self._greet_sent:
+                        llm_out = self.llm.propose_actions({
+                            **snapshot,
+                            "config": {**snapshot["config"], "max_actions_per_cycle": self.cfg.llm_max_actions_per_cycle},
+                        })
+                        actions = llm_out.get("actions", [])
+                    self._greet_sent = True
 
                 valid = self.validate_actions(actions, snapshot)
                 if valid:

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -207,6 +207,24 @@ class BinanceExchange:
             spread_abs = abs(ba - bb) if (bb and ba) else 0.0
             volb = (ws.get("depth_buy", 0.0) or 0.0); vola = (ws.get("depth_sell", 0.0) or 0.0)
             imb = (volb / (volb + vola)) if (volb + vola) > 0 else 0.5
+
+            mkt = (self.exchange.markets or {}).get(sym, {})
+            precision = (mkt.get("precision") or {}).get("price")
+            tick_size = None
+            if precision is not None:
+                try:
+                    tick_size = 10 ** (-int(precision))
+                except Exception:
+                    tick_size = None
+            if tick_size is None:
+                info = mkt.get("info") or {}
+                for f in info.get("filters", []):
+                    if f.get("filterType") == "PRICE_FILTER":
+                        ts = float(f.get("tickSize") or 0.0)
+                        if ts > 0:
+                            tick_size = ts
+                            break
+            tick_size = tick_size or 1e-8
             out.append({
                 "symbol": sym,
                 "price_last": last or mid or 0.0,
@@ -218,6 +236,7 @@ class BinanceExchange:
                 "imbalance": imb,
                 "trade_flow": ws.get("trade_flow", {"buy_ratio":0.5,"streak":0}),
                 "micro_volatility": (spread_abs / (mid or 1.0)) if mid else 0.0,
+                "tick_size": tick_size,
                 "edge_est_bps": 0.0,
                 "score": 0.0,
             })
@@ -262,9 +281,9 @@ class BinanceExchange:
         usd += btc * (pbtc or 0.0)
         return {"balance_usd": float(usd), "balance_btc": float(btc)}
 
-    # ---------- Minimos ----------
+    # ---------- Mínimos ----------
     def global_min_order_btc(self) -> float:
-        # Compat: calcula en BTC a partir del min notional global en USDT
+        """Devuelve el mínimo en BTC calculado a partir del notional en USD."""
         usd = self.global_min_notional_usd()
         try:
             pbtc = float(self.exchange.fetch_ticker("BTC/USDT").get("last") or 0.0)
@@ -273,42 +292,33 @@ class BinanceExchange:
         return float(usd) / (pbtc or 1.0)
 
     def global_min_notional_usd(self) -> float:
-        """Devuelve el mínimo notional (USDT) más bajo que exige Binance entre mercados spot activos con quote estable.
+        """Calcula el mayor ``MIN_NOTIONAL`` entre todos los pares */BTC y lo
+        convierte a USD para obtener el mínimo absoluto con el que cumplir en
+        cualquier mercado BTC.
 
-        Se añade un margen de 0.1 USDT para asegurar que las órdenes
-        cumplen con el mínimo requerido por Binance."""
-        default = 5.0
-        buffer = 0.1
+        No se aplica margen adicional; el pequeño colchón (+0.1 USDT) se añade
+        al momento de enviar órdenes si así se configura desde la UI."""
 
-        # 1) Intentar obtener el mínimo global desde la información del exchange
-        try:
-            info = self.exchange.public_get_exchangeinfo()
-            for f in (info or {}).get("exchangeFilters", []):
-                if f.get("filterType") in ("MIN_NOTIONAL", "NOTIONAL"):
-                    v = float(f.get("minNotional") or f.get("notional") or 0.0)
-                    if v > 0:
-                        return float(v + buffer)
-        except Exception:
-            pass
+        default_usd = 5.0
 
-        # 2) Fallback: recorrer los mercados spot con quote estable
+        # Recorre todos los pares BTC para encontrar el mayor MIN_NOTIONAL en BTC
         try:
             self.load_markets()
         except Exception:
-            # Si la carga de mercados falla devolvemos el fallback seguro
-            return float(default + buffer)
-        min_usd = None
+            return float(default_usd)
+
+        max_btc = 0.0
         for m in self.exchange.markets.values():
             try:
                 if not m.get("active"): continue
                 if m.get("spot") is False: continue
-                quote = (m.get("quote") or "").upper()
-                if quote not in ("USDT","TUSD","FDUSD","BUSD"): continue
-                lim = ((m.get("limits") or {}).get("cost") or {}).get("min", None)
+                if (m.get("quote") or "").upper() != "BTC":
+                    continue
+                val = None
+                lim = ((m.get("limits") or {}).get("cost") or {}).get("min")
                 if isinstance(lim, (int, float)) and lim and lim > 0:
                     val = float(lim)
                 else:
-                    val = None
                     info = m.get("info") or {}
                     for f in info.get("filters", []):
                         if f.get("filterType") in ("MIN_NOTIONAL", "NOTIONAL"):
@@ -316,10 +326,19 @@ class BinanceExchange:
                             if v > 0:
                                 val = v
                                 break
-                if val is None or val < 4.0:
-                    # Ignorar valores anómalamente bajos
+                if val is None:
                     continue
-                min_usd = val if (min_usd is None or val < min_usd) else min_usd
+                if val > max_btc:
+                    max_btc = val
             except Exception:
                 continue
-        return float((min_usd if min_usd is not None else default) + buffer)
+
+        if max_btc <= 0:
+            return float(default_usd)
+
+        try:
+            pbtc = float(self.exchange.fetch_ticker("BTC/USDT").get("last") or 0.0)
+        except Exception:
+            pbtc = 0.0
+
+        return float(max_btc * (pbtc or 0.0)) or float(default_usd)

--- a/llm_client.py
+++ b/llm_client.py
@@ -44,6 +44,20 @@ class LLMClient:
                 pass
         return self._propose_dummy(snapshot)
 
+    def greet(self, message: str = "hola") -> str:
+        if self._openai:
+            try:
+                resp = self._openai.chat.completions.create(
+                    model=self.model,
+                    messages=[{"role": "user", "content": message}],
+                    temperature=self.temp_op,
+                    timeout=20,
+                )
+                return resp.choices[0].message.content or ""
+            except Exception:
+                return ""
+        return ""
+
     # -------------------- OpenAI --------------------
     def _propose_openai(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
         client = self._openai

--- a/ui_app.py
+++ b/ui_app.py
@@ -1,4 +1,4 @@
-import threading, queue, time
+import threading, queue, time, json, os
 import ttkbootstrap as tb
 from ttkbootstrap.constants import *
 from ttkbootstrap.scrolled import ScrolledText
@@ -66,7 +66,10 @@ class App(tb.Window):
         self._engine_live: Engine | None = None
         self.exchange = None
 
+        self._keys_file = os.path.join(os.path.dirname(__file__), ".api_keys.json")
+
         self._build_ui()
+        self._load_saved_keys()
         self._lock_controls(True)
         self.after(250, self._poll_log_queue)
         self.after(800, self._tick_ui_refresh)
@@ -265,6 +268,28 @@ class App(tb.Window):
             from exchange_utils import BinanceExchange
             self.exchange = BinanceExchange(rate_limit=True, sandbox=False)
 
+    def _load_saved_keys(self):
+        try:
+            with open(self._keys_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.var_bin_key.set(data.get("bin_key", ""))
+            self.var_bin_sec.set(data.get("bin_sec", ""))
+            self.var_oai_key.set(data.get("oai_key", ""))
+        except Exception:
+            pass
+
+    def _save_api_keys(self):
+        try:
+            data = {
+                "bin_key": self.var_bin_key.get(),
+                "bin_sec": self.var_bin_sec.get(),
+                "oai_key": self.var_oai_key.get(),
+            }
+            with open(self._keys_file, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+        except Exception:
+            pass
+
     # ------------------- Warmup -------------------
     def _warmup_load_market(self):
         try:
@@ -343,11 +368,11 @@ class App(tb.Window):
         if bool(self.var_use_min_live.get()):
             try:
                 min_usd = self.exchange.global_min_notional_usd()
-                usd = float(min_usd)
+                usd = float(min_usd) + 0.1
                 self._engine_live.cfg.size_usd_live = float(usd if usd > 0 else self._engine_live.cfg.size_usd_live)
                 self.var_size_live.set(round(self._engine_live.cfg.size_usd_live, 2))
                 self.ent_size_live.configure(state="disabled")
-                self.lbl_min_marker.configure(text=f"Mínimo permitido por Binance: {usd:.2f} USDT")
+                self.lbl_min_marker.configure(text=f"Mínimo permitido por Binance: {min_usd:.2f} USDT")
             except Exception:
                 pass
         # LLM
@@ -416,6 +441,7 @@ class App(tb.Window):
         ok_bin = self._apply_binance_keys()
         ok_oai = self._apply_openai_key()
         if ok_bin and ok_oai:
+            self._save_api_keys()
             self._lock_controls(False)
             self.log_append("[APP] APIs verificadas. Desbloqueando interfaz.")
         else:
@@ -446,12 +472,12 @@ class App(tb.Window):
             try:
                 self._ensure_exchange()
                 min_usd = self.exchange.global_min_notional_usd()
-                usd = float(min_usd)
+                usd = float(min_usd) + 0.1
                 self.var_size_live.set(round(usd, 2))
                 if self._engine_live:
                     self._engine_live.cfg.size_usd_live = float(usd)
                 self.ent_size_live.configure(state="disabled")
-                self.lbl_min_marker.configure(text=f"Mínimo permitido por Binance: {usd:.2f} USDT")
+                self.lbl_min_marker.configure(text=f"Mínimo permitido por Binance: {min_usd:.2f} USDT")
             except Exception as e:
                 self.log_append(f"[ENGINE] Error obteniendo mínimo: {e}")
         else:
@@ -504,7 +530,7 @@ class App(tb.Window):
         self.lbl_ws.configure(text=f"WS: {gs.get('latency_ws_ms',0):.0f} ms")
 
         # Tablas
-        self._refresh_market_table(snap.get("pairs", []))
+        self._refresh_market_table(snap.get("candidates") or snap.get("pairs", []))
         self._refresh_open_orders(snap.get("open_orders", []))
         self._refresh_closed_orders(snap.get("closed_orders", []))
 


### PR DESCRIPTION
## Summary
- Usa el `tick_size` real para calcular candidatos cuyo salto mínimo supera dos veces la comisión
- El tamaño mínimo en LIVE toma el mayor `MIN_NOTIONAL` de Binance y solo añade 0.1 USDT de colchón
- Las claves de Binance y OpenAI se guardan en `.api_keys.json` y se recargan automáticamente

## Testing
- `python -m py_compile exchange_utils.py engine.py ui_app.py llm_client.py`
- `python - <<'PY' ...` *(global_min_notional_usd: 5.0; min_order_btc: 5.0)*
- `curl -I https://api.binance.com/api/v3/exchangeInfo` *(403 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e94c16b5c8328ae6ac7c79b4004f0