### PR TITLE
Improve pair selection visibility and LLM call logging

### DIFF
--- a/ui_app.py
+++ b/ui_app.py
@@ -52,6 +52,42 @@ class App(tb.Window):
         except Exception:
             pass
 
+    def _fmt_sats(self, price: float) -> str:
+        """Formato legible para precios en satoshis"""
+        try:
+            sats = int(float(price) * 1e8)
+        except Exception:
+            sats = 0
+        if sats >= 1000:
+            return f"{sats:,}".replace(",", ".")
+        return str(sats)
+
+    def _coerce(self, val: str, col: str):
+        v = str(val).replace("★ ", "")
+        if col == "symbol":
+            return v
+        if col == "price_sats":
+            v = v.replace(".", "")
+        try:
+            return float(v)
+        except Exception:
+            return v
+
+    def _sort_tree(self, col: str, reverse: bool, preserve: bool = False):
+        data = [
+            (self._coerce(self.tree.set(k, col), col), k)
+            for k in self.tree.get_children("")
+        ]
+        try:
+            data.sort(reverse=reverse)
+        except Exception:
+            pass
+        for idx, (_, k) in enumerate(data):
+            self.tree.move(k, "", idx)
+        if not preserve:
+            self._sort_col, self._sort_reverse = col, reverse
+            self.tree.heading(col, command=lambda: self._sort_tree(col, not reverse))
+
     def __init__(self):
         super().__init__(title="AutoBTC - Punto a Punto", themename="cyborg")
         self.geometry("1400x860")
@@ -72,7 +108,7 @@ class App(tb.Window):
         self._load_saved_keys()
         self._lock_controls(True)
         self.after(250, self._poll_log_queue)
-        self.after(800, self._tick_ui_refresh)
+        self.after(500, self._tick_ui_refresh)
         # Precarga de mercado y balance
         self._warmup_thread = threading.Thread(target=self._warmup_load_market, daemon=True)
         self._warmup_thread.start()
@@ -126,16 +162,33 @@ class App(tb.Window):
         frm_mkt = ttk.Labelframe(left, text="Mercado", padding=6)
         frm_mkt.grid(row=0, column=0, sticky="nsew", pady=(0,8))
         frm_mkt.rowconfigure(0, weight=1); frm_mkt.columnconfigure(0, weight=1)
-        cols = ("symbol","score","pct","price_sats","vol_base_k")
+        cols = (
+            "symbol",
+            "score",
+            "pct",
+            "price_sats",
+            "spread_bps",
+            "buy_k",
+            "sell_k",
+            "imb",
+        )
         self.tree = ttk.Treeview(frm_mkt, columns=cols, show="headings")
         style = tb.Style(); style.configure("Treeview", font=("Consolas", 10))
-        headers = [("symbol","Símbolo",160,"w"),
-                   ("score","Score",70,"e"),
-                   ("pct","%24h",70,"e"),
-                   ("price_sats","Precio (sats)",120,"e"),
-                   ("vol_base_k","VolBase(k)",100,"e")]
+        self._sort_col: str | None = None
+        self._sort_reverse: bool = False
+        headers = [
+            ("symbol", "Símbolo", 160, "w"),
+            ("score", "Score", 70, "e"),
+            ("pct", "%24h", 70, "e"),
+            ("price_sats", "Precio (sats)", 120, "e"),
+            ("spread_bps", "Spread(bps)", 100, "e"),
+            ("buy_k", "Buy k", 80, "e"),
+            ("sell_k", "Sell k", 80, "e"),
+            ("imb", "Imb", 70, "e"),
+        ]
         for c, txt, w, an in headers:
-            self.tree.heading(c, text=txt); self.tree.column(c, width=w, anchor=an, stretch=False)
+            self.tree.heading(c, text=txt, command=lambda col=c: self._sort_tree(col, False))
+            self.tree.column(c, width=w, anchor=an, stretch=False)
         vsb = ttk.Scrollbar(frm_mkt, orient="vertical", command=self.tree.yview)
         self.tree.configure(yscrollcommand=vsb.set)
         self.tree.grid(row=0, column=0, sticky="nsew"); vsb.grid(row=0, column=1, sticky="ns")
@@ -148,6 +201,7 @@ class App(tb.Window):
         self.tree.tag_configure('score50', background='#fbbf24')
         self.tree.tag_configure('scoreLow', background='#9ca3af')
         self.tree.tag_configure('veto', background='#ef4444', foreground='white')
+        self.tree.tag_configure('candidate', font=('Consolas', 10, 'bold'))
 
         # Órdenes abiertas
         frm_open = ttk.Labelframe(left, text="Órdenes abiertas", padding=6)
@@ -298,7 +352,7 @@ class App(tb.Window):
             if uni:
                 pairs = self.exchange.fetch_top_metrics(uni[: min(20, len(uni))])
                 if not self._snapshot:
-                    self._refresh_market_table(pairs)
+                    self._refresh_market_table(pairs, [])
             # Mínimo global BTC en el marcador
             try:
                 min_usd = self.exchange.global_min_notional_usd()
@@ -307,6 +361,33 @@ class App(tb.Window):
                 pass
         except Exception as e:
             self.log_append(f"[ENGINE] Warmup error: {e}")
+
+    def _refresh_market_candidates(self):
+        try:
+            self._ensure_exchange()
+            uni = self.exchange.fetch_universe("BTC")[:100]
+            if not uni:
+                return
+            pairs = self.exchange.fetch_top_metrics(uni[: min(20, len(uni))])
+            fee = float(self.cfg.fee_per_side)
+            thr_pct = fee * 2.0 * 100.0
+            cands: List[Dict[str, Any]] = []
+            self.log_append(f"[ENGINE] Buscando pares buenos (umbral {thr_pct:.4f}% basado en comisiones)")
+            for p in pairs:
+                sym = p.get("symbol", "")
+                mid = float(p.get("mid") or p.get("price_last") or 0.0)
+                tick = float(p.get("tick_size") or 1e-8)
+                tick_pct = (tick / mid * 100.0) if mid else 0.0
+                p["tick_pct"] = tick_pct
+                if tick_pct > thr_pct:
+                    p["is_candidate"] = True
+                    cands.append(p)
+                    self.log_append(f"[ENGINE] {sym} tick_pct {tick_pct:.4f}% > {thr_pct:.4f}% -> candidato")
+            self.log_append(f"[ENGINE] Candidatos encontrados: {len(cands)}")
+            self._snapshot = {**self._snapshot, "pairs": pairs, "candidates": cands}
+            self._refresh_market_table(pairs, cands)
+        except Exception as e:
+            self.log_append(f"[ENGINE] Error al refrescar mercado: {e}")
 
     # ------------------- Engine binding -------------------
     def _on_bot_sim(self, *_):
@@ -358,37 +439,37 @@ class App(tb.Window):
         self._engine_sim.cfg.llm_call_interval_ms = secs * 1000
         self._engine_sim.start()
 
-def _start_engine_live(self):
-    def push_snapshot(snap: Dict[str, Any]):
-        self._snapshot = snap
-    self._ensure_exchange()
-    self._engine_live = Engine(
-        ui_push_snapshot=push_snapshot,
-        ui_log=self.log_append,
-        exchange=self.exchange,
-        name="LIVE"
-    )
-    self._engine_live.mode = "LIVE"
-    # tamaño LIVE (mínimo global si toggle ON)
-    if bool(self.var_use_min_live.get()):
-        try:
-            min_usd = self.exchange.global_min_notional_usd()
-            usd = float(min_usd) + 0.1
-            self._engine_live.cfg.size_usd_live = float(
-                usd if usd > 0 else self._engine_live.cfg.size_usd_live
-            )
-            self.var_size_live.set(round(self._engine_live.cfg.size_usd_live, 2))
-            self.ent_size_live.configure(state="disabled")
-            self.lbl_min_marker.configure(text=f"Mínimo permitido por Binance: {min_usd:.2f} USDT")
-        except Exception:
-            pass
-    # LLM
-    self._engine_live.llm.set_model(self.var_llm_model.get())
-    secs = max(1, int(self.var_llm_secs.get()))
-    self._engine_live.cfg.llm_call_interval_ms = secs * 1000
-    # Confirm gate
-    self._engine_live.state.live_confirmed = bool(self.var_live_confirm.get())
-    self._engine_live.start()
+    def _start_engine_live(self):
+        def push_snapshot(snap: Dict[str, Any]):
+            self._snapshot = snap
+        self._ensure_exchange()
+        self._engine_live = Engine(
+            ui_push_snapshot=push_snapshot,
+            ui_log=self.log_append,
+            exchange=self.exchange,
+            name="LIVE"
+        )
+        self._engine_live.mode = "LIVE"
+        # tamaño LIVE (mínimo global si toggle ON)
+        if bool(self.var_use_min_live.get()):
+            try:
+                min_usd = self.exchange.global_min_notional_usd()
+                usd = float(min_usd) + 0.1
+                self._engine_live.cfg.size_usd_live = float(
+                    usd if usd > 0 else self._engine_live.cfg.size_usd_live
+                )
+                self.var_size_live.set(round(self._engine_live.cfg.size_usd_live, 2))
+                self.ent_size_live.configure(state="disabled")
+                self.lbl_min_marker.configure(text=f"Mínimo permitido por Binance: {min_usd:.2f} USDT")
+            except Exception:
+                pass
+        # LLM
+        self._engine_live.llm.set_model(self.var_llm_model.get())
+        secs = max(1, int(self.var_llm_secs.get()))
+        self._engine_live.cfg.llm_call_interval_ms = secs * 1000
+        # Confirm gate
+        self._engine_live.state.live_confirmed = bool(self.var_live_confirm.get())
+        self._engine_live.start()
 
 
     # ------------------- Actions -------------------
@@ -452,6 +533,7 @@ def _start_engine_live(self):
             self._save_api_keys()
             self._lock_controls(False)
             self.log_append("[APP] APIs verificadas. Desbloqueando interfaz.")
+            self._refresh_market_candidates()
         else:
             self.log_append("[APP] Error verificando APIs. Revísalas e intenta nuevamente.")
 
@@ -480,16 +562,7 @@ def _start_engine_live(self):
             try:
                 self._ensure_exchange()
                 min_usd = self.exchange.global_min_notional_usd()
-                usd = float(min_usd) + 0.01
-
-                usd = float(min_usd) + 0.01
-
                 usd = float(min_usd) + 0.1
-
-                usd = float(min_usd) + 0.01
-
-                usd = float(min_usd) + 0.1
-
                 self.var_size_live.set(round(usd, 2))
                 if self._engine_live:
                     self._engine_live.cfg.size_usd_live = float(usd)
@@ -547,7 +620,10 @@ def _start_engine_live(self):
         self.lbl_ws.configure(text=f"WS: {gs.get('latency_ws_ms',0):.0f} ms")
 
         # Tablas
-        self._refresh_market_table(snap.get("candidates") or snap.get("pairs", []))
+        self._refresh_market_table(
+            snap.get("pairs", []),
+            snap.get("candidates", []),
+        )
         self._refresh_open_orders(snap.get("open_orders", []))
         self._refresh_closed_orders(snap.get("closed_orders", []))
 
@@ -559,19 +635,32 @@ def _start_engine_live(self):
                 self.txt_info.insert("end", f"• {r}\n")
                 self.log_append(f"[ENGINE] {r}")
 
-        self.after(1000, self._tick_ui_refresh)
+        self.after(500, self._tick_ui_refresh)
 
-    def _refresh_market_table(self, pairs: List[Dict[str, Any]]):
-        for i in self.tree.get_children():
-            self.tree.delete(i)
+    def _refresh_market_table(self, pairs: List[Dict[str, Any]], candidates: List[Dict[str, Any]]):
+        cand_syms = {c.get("symbol") for c in candidates}
+        existing = {}
+        for iid in self.tree.get_children():
+            sym_val = self.tree.set(iid, "symbol").replace("★ ", "")
+            existing[sym_val] = iid
         for p in pairs:
-            item = self.tree.insert("", "end", values=(
-                p.get("symbol",""),
+            sym = p.get("symbol", "")
+            display_sym = f"★ {sym}" if sym in cand_syms else sym
+            values = (
+                display_sym,
                 f"{p.get('score',0.0):.1f}",
                 f"{p.get('pct_change_window',0.0):+.2f}",
-                f"{(p.get('price_last',0.0)*1e8):.0f}",
-                f"{(p.get('depth',{}).get('buy',0.0)+p.get('depth',{}).get('sell',0.0))/1000:.1f}",
-            ))
+                self._fmt_sats(p.get('price_last',0.0)),
+                f"{(p.get('spread_abs',0.0)/(p.get('mid',1.0) or 1.0))*1e4:.1f}",
+                f"{p.get('depth',{}).get('buy',0.0)/1000:.1f}",
+                f"{p.get('depth',{}).get('sell',0.0)/1000:.1f}",
+                f"{p.get('imbalance',0.5):.2f}",
+            )
+            item = existing.pop(sym, None)
+            if item:
+                self.tree.item(item, values=values)
+            else:
+                item = self.tree.insert("", "end", values=values)
             try:
                 sc = float(p.get('score',0.0))
                 tag = 'scoreLow'
@@ -580,9 +669,16 @@ def _start_engine_live(self):
                 elif sc >= 65: tag = 'score65'
                 elif sc >= 60: tag = 'score64'
                 elif sc >= 50: tag = 'score59'
-                self.tree.item(item, tags=(tag,))
+                tags = [tag]
+                if sym in cand_syms:
+                    tags.append('candidate')
+                self.tree.item(item, tags=tuple(tags))
             except Exception:
                 pass
+        for iid in existing.values():
+            self.tree.delete(iid)
+        if self._sort_col:
+            self._sort_tree(self._sort_col, self._sort_reverse, preserve=True)
 
     def _refresh_open_orders(self, orders: List[Dict[str, Any]]):
         for i in self.tree_open.get_children():


### PR DESCRIPTION
## Summary
- Search and display good pairs right after API verification so the market table flags candidates immediately
- Skip initial LLM call when no open orders or good pairs, logging each decision
- Log every LLM call or skip with candidate and open-order counts
- Expand market table with sortable metrics, clearer pricing and score-based colors

## Testing
- `python -m py_compile engine.py ui_app.py`
- `python main.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689ea90a66fc8328aa01752f82aeadb4