### PR TITLE
Refine scoring and market table visuals

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -72,9 +72,24 @@ class Engine(threading.Thread):
                 continue
             best_ask = par.get("best_ask", 0.0)
             best_bid = par.get("best_bid", 0.0)
-            if o["side"] == "buy" and best_ask and o["price"] >= best_ask:
-                self._register_fill(o, fill_price=best_ask)
-                to_close.append(oid)
+            if o["side"] == "buy":
+                # Cancel if order price is not the nearest buy to best ask
+                if best_bid and o["price"] < best_bid:
+                    self._open_orders.pop(oid, None)
+                    self._log_audit("CANCEL", sym, "buy not at top bid")
+                    continue
+                bid_qty = par.get("bid_top_qty", 0.0)
+                ask_qty = par.get("ask_top_qty", 0.0)
+                total_qty = bid_qty + ask_qty
+                if total_qty > 0:
+                    if bid_qty <= 0.1 * total_qty:
+                        self._open_orders.pop(oid, None)
+                        self._log_audit("CANCEL", sym, "bid support <=10%")
+                        continue
+                    # if bid_qty >=60% we simply continue monitoring
+                if best_ask and o["price"] >= best_ask:
+                    self._register_fill(o, fill_price=best_ask)
+                    to_close.append(oid)
             elif o["side"] == "sell" and best_bid and o["price"] <= best_bid:
                 self._register_fill(o, fill_price=best_bid)
                 to_close.append(oid)
@@ -164,9 +179,12 @@ class Engine(threading.Thread):
                 "pct_change_window": p.get("pct_change_window", 0.0),
                 "depth_buy": ms.get("depth_buy", p.get("depth",{}).get("buy",0.0)),
                 "depth_sell": ms.get("depth_sell", p.get("depth",{}).get("sell",0.0)),
+                "best_bid_qty": ms.get("bid_top_qty", p.get("bid_top_qty",0.0)),
+                "best_ask_qty": ms.get("ask_top_qty", p.get("ask_top_qty",0.0)),
+                "trade_flow_buy_ratio": ms.get("trade_flow", {}).get("buy_ratio", p.get("trade_flow", {}).get("buy_ratio", 0.5)),
+                "mid": p.get("mid", 0.0),
                 "spread_bps": p.get("spread_bps", 0.0),
                 "tick_price_bps": p.get("tick_price_bps", 8.0),
-                "trade_flow": p.get("trade_flow", {"buy_ratio": 0.5}),
                 "base_volume": p.get("depth", {}).get("buy", 0.0) + p.get("depth", {}).get("sell", 0.0),
                 "micro_volatility": p.get("micro_volatility", 0.0),
                 "weights": self.cfg.weights,

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -101,6 +101,8 @@ class BinanceWS:
                 ba = asks[0][0] if asks else 0.0
                 mid = (bb+ba)/2.0 if bb and ba else (bb or ba or 0.0)
                 volb = sum(q for _,q in bids[:5]); vola = sum(q for _,q in asks[:5])
+                top_bid_qty = bids[0][1] if bids else 0.0
+                top_ask_qty = asks[0][1] if asks else 0.0
                 spread = (ba-bb) if (bb and ba) else 0.0
                 imb = (volb/(volb+vola)) if (volb+vola)>0 else 0.5
                 tf_buy = float(flow.get("buy",0)); tf_sell = float(flow.get("sell",0))
@@ -109,6 +111,7 @@ class BinanceWS:
                     "best_bid": bb, "best_ask": ba, "mid": mid,
                     "spread_abs": spread, "spread_pct": (spread/mid*100.0) if mid else 0.0,
                     "depth_buy": volb, "depth_sell": vola, "imbalance": imb,
+                    "bid_top_qty": top_bid_qty, "ask_top_qty": top_ask_qty,
                     "trade_flow": {"buy_ratio": buy_ratio, "streak": int(flow.get("streak",0))},
                 }
         return out
@@ -207,6 +210,8 @@ class BinanceExchange:
             spread_abs = abs(ba - bb) if (bb and ba) else 0.0
             volb = (ws.get("depth_buy", 0.0) or 0.0); vola = (ws.get("depth_sell", 0.0) or 0.0)
             imb = (volb / (volb + vola)) if (volb + vola) > 0 else 0.5
+            topb = ws.get("bid_top_qty", 0.0)
+            topa = ws.get("ask_top_qty", 0.0)
 
             mkt = (self.exchange.markets or {}).get(sym, {})
             precision = (mkt.get("precision") or {}).get("price")
@@ -234,6 +239,7 @@ class BinanceExchange:
                 "pct_change_window": float(t.get("percentage") or 0.0) if t else 0.0,
                 "depth": {"buy": volb, "sell": vola},
                 "imbalance": imb,
+                "bid_top_qty": topb, "ask_top_qty": topa,
                 "trade_flow": ws.get("trade_flow", {"buy_ratio":0.5,"streak":0}),
                 "micro_volatility": (spread_abs / (mid or 1.0)) if mid else 0.0,
                 "tick_size": tick_size,

--- a/scoring.py
+++ b/scoring.py
@@ -9,43 +9,53 @@ def _nz(x, eps=1e-12):
 
 def compute_score(features: Dict) -> float:
     """
-    Nuevo scoring (0..100) con normalización simple:
-    - momentum: |pct_change| en ventana (0..2% mapeado a 0..1)
-    - depth_quality: log10(1 + (depth_buy+depth_sell))
-    - ob_imbalance: favorece 0.6..0.8 compradores o 0.2..0.4 vendedores (campana)
-    - micro_volatility: penalización suave por volatilidad excesiva
-    - spread_penalty: penaliza spreads amplios frente al tick proxy
-    Pesos por defecto: momentum 30, depth 25, imbalance 20, spread 15, microvol 10
+    Calcula un score (0..100) ponderado según:
+    1. Presión inmediata del libro de órdenes (top bid vs top ask).
+    2. Flujo de órdenes reciente (ratio de compras vs ventas).
+    3. Momentum del precio en la ventana configurada.
+    4. Profundidad agregada del libro.
+    5. Penalización por spread amplio.
+    6. Penalización por micro-volatilidad.
+    La primera consideración tiene el mayor peso y la última el menor.
     """
     pct = abs(float(features.get("pct_change_window", 0.0)))
-    # 0..2% -> 0..1
     momentum = _clamp(pct / 2.0, 0.0, 1.0)
 
     depth_buy = float(features.get("depth_buy", 0.0))
     depth_sell = float(features.get("depth_sell", 0.0))
     depth = max(0.0, depth_buy + depth_sell)
-    depth_quality = math.log10(1.0 + depth) / 6.0  # 0..~1 para rangos comunes
+    depth_quality = math.log10(1.0 + depth) / 6.0
 
-    imb = float(features.get("imbalance", 0.5))
-    # campana centrada en 0.7 y 0.3 (dos colinas); pick comprador o vendedor fuerte
-    bell = math.exp(-((imb-0.7)**2)/(2*0.07**2)) + math.exp(-((imb-0.3)**2)/(2*0.07**2))
-    ob_imbalance = _clamp(bell/2.0, 0.0, 1.0)
+    best_bid_qty = float(features.get("best_bid_qty", 0.0))
+    best_ask_qty = float(features.get("best_ask_qty", 0.0))
+    pressure_raw = best_bid_qty / _nz(best_bid_qty + best_ask_qty)
+    orderbook_pressure = _clamp(abs(pressure_raw - 0.5) * 2.0, 0.0, 1.0)
+
+    buy_ratio = float(features.get("trade_flow_buy_ratio", 0.5))
+    flow_bias = _clamp(abs(buy_ratio - 0.5) * 2.0, 0.0, 1.0)
 
     micro_vol = float(features.get("micro_volatility", 0.0))
-    # volatilidad deseable moderada: penalización por colas pesadas
     micro_vol_pen = 1.0 / (1.0 + 50.0 * micro_vol)
 
-    spread = float(features.get("spread_abs", 0.0))  # diferencia absoluta
+    spread = float(features.get("spread_abs", 0.0))
     price = abs(float(features.get("mid", 0.0)))
-    tick = max(price * 1e-6, 1e-8)  # proxy
+    tick = max(price * 1e-6, 1e-8)
     spread_penalty = 1.0 / (1.0 + (spread / _nz(tick)))
 
-    w = features.get("weights") or {"momentum":30, "depth":25, "imbalance":20, "spread":15, "microvol":10}
+    w = features.get("weights") or {
+        "pressure": 30,
+        "flow": 25,
+        "momentum": 20,
+        "depth": 15,
+        "spread": 5,
+        "microvol": 5,
+    }
     score = (
-        momentum * w.get("momentum",30) +
-        depth_quality * w.get("depth",25) +
-        ob_imbalance * w.get("imbalance",20) +
-        spread_penalty * w.get("spread",15) +
-        micro_vol_pen * w.get("microvol",10)
-    ) / 1.0
+        orderbook_pressure * w.get("pressure", 30) +
+        flow_bias * w.get("flow", 25) +
+        momentum * w.get("momentum", 20) +
+        depth_quality * w.get("depth", 15) +
+        spread_penalty * w.get("spread", 5) +
+        micro_vol_pen * w.get("microvol", 5)
+    )
     return float(_clamp(score, 0.0, 100.0))


### PR DESCRIPTION
## Summary
- Revamp pair scoring using order-book pressure, trade flow, momentum, depth and volatility.
- Streamline market table: remove spread, show top bid/ask quantities, and color rows by score.
- Cancel buy orders when not top bid or when bid support vanishes.
- Fetch order-book data to populate Buy Qty, Sell Qty, LMB and to rank pairs by score.

## Testing
- `python -m py_compile exchange_utils.py engine.py scoring.py ui_app.py`


------
https://chatgpt.com/codex/tasks/task_e_689f5693b584832896a4caa7081b7b22