### PR TITLE
Throttle candidate refresh and broaden market scan

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,7 +39,7 @@ class Defaults:
     pct_window: str = "1h"  # "24h"|"1h"|"5m"
 
     # Universo / otros
-    universe_quote: str = "BTC"
+    universe_quote: str = "ALL"
     topN: int = 20  # pares que mostramos al LLM / UI
     log_dir: str = "./logs"
     initial_balance_usd: float = 10000.0

--- a/engine.py
+++ b/engine.py
@@ -8,7 +8,7 @@ from llm_client import LLMClient
 class Engine(threading.Thread):
     """
     Motor principal con modos SIM/LIVE.
-    - Snapshot del universo */BTC con WS+REST
+    - Snapshot del universo completo con WS+REST
     - LLM (OpenAI si hay clave; heurística si no)
     - Validación dura y ejecución (SIM/LIVE)
     - Razones cuando no opera
@@ -35,7 +35,8 @@ class Engine(threading.Thread):
         self._last_reasons: List[str] = []
         self._first_call_done: bool = False
         self._last_auto_ts: float = 0.0
-        self._greet_sent: bool = False
+        self._cand_cache: List[Dict[str, Any]] = []
+        self._cand_cache_ts: float = 0.0
 
         os.makedirs(self.cfg.log_dir, exist_ok=True)
         self._audit_file = os.path.join(self.cfg.log_dir, "audit.csv")
@@ -72,9 +73,24 @@ class Engine(threading.Thread):
                 continue
             best_ask = par.get("best_ask", 0.0)
             best_bid = par.get("best_bid", 0.0)
-            if o["side"] == "buy" and best_ask and o["price"] >= best_ask:
-                self._register_fill(o, fill_price=best_ask)
-                to_close.append(oid)
+            if o["side"] == "buy":
+                # Cancel if order price is not the nearest buy to best ask
+                if best_bid and o["price"] < best_bid:
+                    self._open_orders.pop(oid, None)
+                    self._log_audit("CANCEL", sym, "buy not at top bid")
+                    continue
+                bid_qty = par.get("bid_top_qty", 0.0)
+                ask_qty = par.get("ask_top_qty", 0.0)
+                total_qty = bid_qty + ask_qty
+                if total_qty > 0:
+                    if bid_qty <= 0.1 * total_qty:
+                        self._open_orders.pop(oid, None)
+                        self._log_audit("CANCEL", sym, "bid support <=10%")
+                        continue
+                    # if bid_qty >=60% we simply continue monitoring
+                if best_ask and o["price"] >= best_ask:
+                    self._register_fill(o, fill_price=best_ask)
+                    to_close.append(oid)
             elif o["side"] == "sell" and best_bid and o["price"] <= best_bid:
                 self._register_fill(o, fill_price=best_bid)
                 to_close.append(oid)
@@ -128,7 +144,6 @@ class Engine(threading.Thread):
         cands: List[Dict[str, Any]] = []
         self.ui_log(f"[ENGINE {self.name}] Buscando pares buenos (umbral {thr_pct:.4f}% basado en comisiones)")
         for p in snapshot.get("pairs", []):
-            sym = p.get("symbol", "")
             mid = float(p.get("mid") or p.get("price_last") or 0.0)
             tick = float(p.get("tick_size") or 1e-8)
             tick_pct = (tick / mid * 100.0) if mid else 0.0
@@ -136,15 +151,12 @@ class Engine(threading.Thread):
             if tick_pct > thr_pct:
                 p["is_candidate"] = True
                 cands.append(p)
-                self.ui_log(
-                    f"[ENGINE {self.name}] {sym} tick_pct {tick_pct:.4f}% > {thr_pct:.4f}% -> candidato"
-                )
         self.ui_log(f"[ENGINE {self.name}] Candidatos encontrados: {len(cands)}")
         return cands
 
     def build_snapshot(self) -> Dict[str, Any]:
         universe = self.exchange.fetch_universe(self.cfg.universe_quote)[:200]
-        pairs = self.exchange.fetch_top_metrics(universe[: self.cfg.topN])
+        pairs = self.exchange.fetch_top_metrics(universe)
         # Collector for selected symbols
         try:
             self.exchange.ensure_collector([p['symbol'] for p in pairs], interval_ms=800)
@@ -164,9 +176,12 @@ class Engine(threading.Thread):
                 "pct_change_window": p.get("pct_change_window", 0.0),
                 "depth_buy": ms.get("depth_buy", p.get("depth",{}).get("buy",0.0)),
                 "depth_sell": ms.get("depth_sell", p.get("depth",{}).get("sell",0.0)),
+                "best_bid_qty": ms.get("bid_top_qty", p.get("bid_top_qty",0.0)),
+                "best_ask_qty": ms.get("ask_top_qty", p.get("ask_top_qty",0.0)),
+                "trade_flow_buy_ratio": ms.get("trade_flow", {}).get("buy_ratio", p.get("trade_flow", {}).get("buy_ratio", 0.5)),
+                "mid": p.get("mid", 0.0),
                 "spread_bps": p.get("spread_bps", 0.0),
                 "tick_price_bps": p.get("tick_price_bps", 8.0),
-                "trade_flow": p.get("trade_flow", {"buy_ratio": 0.5}),
                 "base_volume": p.get("depth", {}).get("buy", 0.0) + p.get("depth", {}).get("sell", 0.0),
                 "micro_volatility": p.get("micro_volatility", 0.0),
                 "weights": self.cfg.weights,
@@ -174,6 +189,7 @@ class Engine(threading.Thread):
             p["score"] = compute_score(features)
 
         pairs.sort(key=lambda x: (-x.get("score", 0.0), -x.get("edge_est_bps", 0.0)))
+        pairs = pairs[: self.cfg.topN]
 
         try:
             _b = self.exchange.fetch_balances_summary()
@@ -186,13 +202,18 @@ class Engine(threading.Thread):
             self.state.balance_usd = max(self.state.balance_usd, 1000.0)
         self._sim_mark_to_market(pairs)
 
-        # ---- Selección de candidatos (antes de construir snapshot) ----
-        candidates = self._find_candidates({
-            "pairs": pairs,
-            "config": {"fee_per_side": self.cfg.fee_per_side},
-        })
-        
-        self.ui_log(f"[ENGINE {self.name}] Evaluados {len(pairs)} pares; {len(candidates)} candidatos")
+        # ---- Selección de candidatos (cacheada a 30s) ----
+        now = time.monotonic()
+        if now - self._cand_cache_ts >= 30.0:
+            self._cand_cache = self._find_candidates({
+                "pairs": pairs,
+                "config": {"fee_per_side": self.cfg.fee_per_side},
+            })
+            self._cand_cache_ts = now
+            self.ui_log(
+                f"[ENGINE {self.name}] Evaluados {len(pairs)} pares; {len(self._cand_cache)} candidatos"
+            )
+        candidates = list(self._cand_cache)
         snap = {
             "ts": int(time.time()*1000),
             "global_state": {
@@ -384,6 +405,13 @@ def _log_audit(self, event: str, sym: str, detail: str):
         return False
 
     def run(self):
+        try:
+            greet_msg = self.llm.greet("hola")
+            if greet_msg:
+                self.ui_log(f"[LLM] {greet_msg}")
+                self._last_reasons = [f"LLM: {greet_msg}"]
+        except Exception:
+            pass
         while not self.is_stopped():
             try:
                 snapshot = self.build_snapshot()
@@ -425,21 +453,14 @@ def _log_audit(self, event: str, sym: str, detail: str):
                         self._last_auto_ts = now_ms
 
                 actions: List[Dict[str, Any]] = []
+                greet_msg = ""
                 if do_call:
                     try:
                         greet_msg = self.llm.greet("hola")
                         if greet_msg:
                             self.ui_log(f"[LLM] {greet_msg}")
                     except Exception:
-                        pass
-
-                    if self._greet_sent:
-                        llm_out = self.llm.propose_actions({
-                            **snapshot,
-                            "config": {**snapshot["config"], "max_actions_per_cycle": self.cfg.llm_max_actions_per_cycle},
-                        })
-                        actions = llm_out.get("actions", [])
-                    self._greet_sent = True
+                        greet_msg = ""
 
                     llm_out = self.llm.propose_actions({
                         **snapshot,
@@ -455,6 +476,9 @@ def _log_audit(self, event: str, sym: str, detail: str):
                     self._last_reasons = self._compute_reasons(actions, snapshot, candidates, open_count)
                     for r in self._last_reasons:
                         self.ui_log(f"[ENGINE {self.name}] {r}")
+
+                if greet_msg:
+                    self._last_reasons.append(f"LLM: {greet_msg}")
 
                 # Empuja estado nuevo
                 self.ui_push_snapshot(self.build_snapshot())

--- a/scoring.py
+++ b/scoring.py
@@ -9,43 +9,53 @@ def _nz(x, eps=1e-12):
 
 def compute_score(features: Dict) -> float:
     """
-    Nuevo scoring (0..100) con normalización simple:
-    - momentum: |pct_change| en ventana (0..2% mapeado a 0..1)
-    - depth_quality: log10(1 + (depth_buy+depth_sell))
-    - ob_imbalance: favorece 0.6..0.8 compradores o 0.2..0.4 vendedores (campana)
-    - micro_volatility: penalización suave por volatilidad excesiva
-    - spread_penalty: penaliza spreads amplios frente al tick proxy
-    Pesos por defecto: momentum 30, depth 25, imbalance 20, spread 15, microvol 10
+    Calcula un score (0..100) ponderado según:
+    1. Presión inmediata del libro de órdenes (top bid vs top ask).
+    2. Flujo de órdenes reciente (ratio de compras vs ventas).
+    3. Momentum del precio en la ventana configurada.
+    4. Profundidad agregada del libro.
+    5. Penalización por spread amplio.
+    6. Penalización por micro-volatilidad.
+    La primera consideración tiene el mayor peso y la última el menor.
     """
     pct = abs(float(features.get("pct_change_window", 0.0)))
-    # 0..2% -> 0..1
     momentum = _clamp(pct / 2.0, 0.0, 1.0)
 
     depth_buy = float(features.get("depth_buy", 0.0))
     depth_sell = float(features.get("depth_sell", 0.0))
     depth = max(0.0, depth_buy + depth_sell)
-    depth_quality = math.log10(1.0 + depth) / 6.0  # 0..~1 para rangos comunes
+    depth_quality = math.log10(1.0 + depth) / 6.0
 
-    imb = float(features.get("imbalance", 0.5))
-    # campana centrada en 0.7 y 0.3 (dos colinas); pick comprador o vendedor fuerte
-    bell = math.exp(-((imb-0.7)**2)/(2*0.07**2)) + math.exp(-((imb-0.3)**2)/(2*0.07**2))
-    ob_imbalance = _clamp(bell/2.0, 0.0, 1.0)
+    best_bid_qty = float(features.get("best_bid_qty", 0.0))
+    best_ask_qty = float(features.get("best_ask_qty", 0.0))
+    pressure_raw = best_bid_qty / _nz(best_bid_qty + best_ask_qty)
+    orderbook_pressure = _clamp(abs(pressure_raw - 0.5) * 2.0, 0.0, 1.0)
+
+    buy_ratio = float(features.get("trade_flow_buy_ratio", 0.5))
+    flow_bias = _clamp(abs(buy_ratio - 0.5) * 2.0, 0.0, 1.0)
 
     micro_vol = float(features.get("micro_volatility", 0.0))
-    # volatilidad deseable moderada: penalización por colas pesadas
     micro_vol_pen = 1.0 / (1.0 + 50.0 * micro_vol)
 
-    spread = float(features.get("spread_abs", 0.0))  # diferencia absoluta
+    spread = float(features.get("spread_abs", 0.0))
     price = abs(float(features.get("mid", 0.0)))
-    tick = max(price * 1e-6, 1e-8)  # proxy
+    tick = max(price * 1e-6, 1e-8)
     spread_penalty = 1.0 / (1.0 + (spread / _nz(tick)))
 
-    w = features.get("weights") or {"momentum":30, "depth":25, "imbalance":20, "spread":15, "microvol":10}
+    w = features.get("weights") or {
+        "pressure": 30,
+        "flow": 25,
+        "momentum": 20,
+        "depth": 15,
+        "spread": 5,
+        "microvol": 5,
+    }
     score = (
-        momentum * w.get("momentum",30) +
-        depth_quality * w.get("depth",25) +
-        ob_imbalance * w.get("imbalance",20) +
-        spread_penalty * w.get("spread",15) +
-        micro_vol_pen * w.get("microvol",10)
-    ) / 1.0
+        orderbook_pressure * w.get("pressure", 30) +
+        flow_bias * w.get("flow", 25) +
+        momentum * w.get("momentum", 20) +
+        depth_quality * w.get("depth", 15) +
+        spread_penalty * w.get("spread", 5) +
+        micro_vol_pen * w.get("microvol", 5)
+    )
     return float(_clamp(score, 0.0, 100.0))

--- a/ui_app.py
+++ b/ui_app.py
@@ -63,7 +63,7 @@ class App(tb.Window):
         return str(sats)
 
     def _coerce(self, val: str, col: str):
-        v = str(val).replace("★ ", "")
+        v = str(val)
         if col == "symbol":
             return v
         if col == "price_sats":
@@ -108,11 +108,12 @@ class App(tb.Window):
         self._load_saved_keys()
         self._lock_controls(True)
         self.after(250, self._poll_log_queue)
-        self.after(500, self._tick_ui_refresh)
+        self.after(4000, self._tick_ui_refresh)
         # Precarga de mercado y balance
         self._warmup_thread = threading.Thread(target=self._warmup_load_market, daemon=True)
         self._warmup_thread.start()
         self.after(2000, self._tick_balance_refresh)
+        self._last_cand_refresh = 0.0
 
     # ------------------- UI -------------------
     def _build_ui(self):
@@ -167,9 +168,8 @@ class App(tb.Window):
             "score",
             "pct",
             "price_sats",
-            "spread_bps",
-            "buy_k",
-            "sell_k",
+            "buy_qty",
+            "sell_qty",
             "imb",
         )
         self.tree = ttk.Treeview(frm_mkt, columns=cols, show="headings")
@@ -181,9 +181,8 @@ class App(tb.Window):
             ("score", "Score", 70, "e"),
             ("pct", "%24h", 70, "e"),
             ("price_sats", "Precio (sats)", 120, "e"),
-            ("spread_bps", "Spread(bps)", 100, "e"),
-            ("buy_k", "Buy k", 80, "e"),
-            ("sell_k", "Sell k", 80, "e"),
+            ("buy_qty", "Buy Qty $", 100, "e"),
+            ("sell_qty", "Sell Qty $", 100, "e"),
             ("imb", "Imb", 70, "e"),
         ]
         for c, txt, w, an in headers:
@@ -192,14 +191,17 @@ class App(tb.Window):
         vsb = ttk.Scrollbar(frm_mkt, orient="vertical", command=self.tree.yview)
         self.tree.configure(yscrollcommand=vsb.set)
         self.tree.grid(row=0, column=0, sticky="nsew"); vsb.grid(row=0, column=1, sticky="ns")
-        # Colores por score (fino)
-        self.tree.tag_configure('score90', background='#0e7a3b')
-        self.tree.tag_configure('score80', background='#16a34a')
-        self.tree.tag_configure('score65', background='#22c55e')
-        self.tree.tag_configure('score64', background='#ffd24d')
-        self.tree.tag_configure('score59', background='#f59e0b')
-        self.tree.tag_configure('score50', background='#fbbf24')
-        self.tree.tag_configure('scoreLow', background='#9ca3af')
+        ttk.Label(frm_mkt, text="Imb: >0.5 compras dominan, <0.5 ventas").grid(row=1, column=0, columnspan=2, sticky="w", pady=(4,0))
+        # Colores por score (fino) en texto
+        self.tree.tag_configure('score95', foreground='#166534')
+        self.tree.tag_configure('score90', foreground='#15803d')
+        self.tree.tag_configure('score80', foreground='#16a34a')
+        self.tree.tag_configure('score70', foreground='#22c55e')
+        self.tree.tag_configure('score60', foreground='#84cc16')
+        self.tree.tag_configure('score50', foreground='#eab308')
+        self.tree.tag_configure('score40', foreground='#f97316')
+        self.tree.tag_configure('score30', foreground='#f43f5e')
+        self.tree.tag_configure('scoreLow', foreground='#b91c1c')
         self.tree.tag_configure('veto', background='#ef4444', foreground='white')
         self.tree.tag_configure('candidate', font=('Consolas', 10, 'bold'))
 
@@ -242,6 +244,8 @@ class App(tb.Window):
         right = ttk.Frame(self, padding=(0, 0, 10, 10))
         right.grid(row=1, column=1, sticky="nsew")
         right.columnconfigure(0, weight=1)
+        right.rowconfigure(5, weight=1)
+        right.rowconfigure(6, weight=1)
 
         ttk.Label(right, text="Ajustes").grid(row=0, column=0, sticky="w", pady=(0,6))
 
@@ -298,17 +302,17 @@ class App(tb.Window):
 
         # Info / razones
         frm_info = ttk.Labelframe(right, text="Información / Razones", padding=8)
-        frm_info.grid(row=5, column=0, sticky="nsew", pady=6)
+        frm_info.grid(row=5, column=0, sticky="nsew", pady=(6, 0))
         frm_info.rowconfigure(0, weight=1); frm_info.columnconfigure(0, weight=1)
         self.txt_info = ScrolledText(frm_info, height=12, autohide=True, wrap="word")
         self.txt_info.grid(row=0, column=0, sticky="nsew")
 
-        # Footer log
-        footer = ttk.Labelframe(self, text="Log", padding=10)
-        footer.grid(row=2, column=0, columnspan=2, sticky="ew")
-        footer.columnconfigure(0, weight=1)
-        self.txt_log = ScrolledText(footer, height=6, autohide=True, wrap="none")
-        self.txt_log.grid(row=0, column=0, sticky="ew")
+        # Log debajo de información
+        frm_log = ttk.Labelframe(right, text="Log", padding=8)
+        frm_log.grid(row=6, column=0, sticky="nsew", pady=6)
+        frm_log.rowconfigure(0, weight=1); frm_log.columnconfigure(0, weight=1)
+        self.txt_log = ScrolledText(frm_log, height=6, autohide=True, wrap="none")
+        self.txt_log.grid(row=0, column=0, sticky="nsew")
 
         # Bindings
         self.var_bot_sim.trace_add("write", self._on_bot_sim)
@@ -348,7 +352,7 @@ class App(tb.Window):
     def _warmup_load_market(self):
         try:
             self._ensure_exchange()
-            uni = self.exchange.fetch_universe("BTC")[:100]
+            uni = self.exchange.fetch_universe(self.cfg.universe_quote)[:100]
             if uni:
                 pairs = self.exchange.fetch_top_metrics(uni[: min(20, len(uni))])
                 if not self._snapshot:
@@ -365,7 +369,7 @@ class App(tb.Window):
     def _refresh_market_candidates(self):
         try:
             self._ensure_exchange()
-            uni = self.exchange.fetch_universe("BTC")[:100]
+            uni = self.exchange.fetch_universe(self.cfg.universe_quote)[:100]
             if not uni:
                 return
             pairs = self.exchange.fetch_top_metrics(uni[: min(20, len(uni))])
@@ -374,7 +378,6 @@ class App(tb.Window):
             cands: List[Dict[str, Any]] = []
             self.log_append(f"[ENGINE] Buscando pares buenos (umbral {thr_pct:.4f}% basado en comisiones)")
             for p in pairs:
-                sym = p.get("symbol", "")
                 mid = float(p.get("mid") or p.get("price_last") or 0.0)
                 tick = float(p.get("tick_size") or 1e-8)
                 tick_pct = (tick / mid * 100.0) if mid else 0.0
@@ -382,7 +385,6 @@ class App(tb.Window):
                 if tick_pct > thr_pct:
                     p["is_candidate"] = True
                     cands.append(p)
-                    self.log_append(f"[ENGINE] {sym} tick_pct {tick_pct:.4f}% > {thr_pct:.4f}% -> candidato")
             self.log_append(f"[ENGINE] Candidatos encontrados: {len(cands)}")
             self._snapshot = {**self._snapshot, "pairs": pairs, "candidates": cands}
             self._refresh_market_table(pairs, cands)
@@ -627,6 +629,11 @@ class App(tb.Window):
         self._refresh_open_orders(snap.get("open_orders", []))
         self._refresh_closed_orders(snap.get("closed_orders", []))
 
+        now = time.time()
+        if now - getattr(self, "_last_cand_refresh", 0) > 30:
+            self._last_cand_refresh = now
+            threading.Thread(target=self._refresh_market_candidates, daemon=True).start()
+
         # Razones
         reasons = snap.get("reasons", [])
         if reasons:
@@ -635,26 +642,34 @@ class App(tb.Window):
                 self.txt_info.insert("end", f"• {r}\n")
                 self.log_append(f"[ENGINE] {r}")
 
-        self.after(500, self._tick_ui_refresh)
+        self.after(4000, self._tick_ui_refresh)
 
     def _refresh_market_table(self, pairs: List[Dict[str, Any]], candidates: List[Dict[str, Any]]):
         cand_syms = {c.get("symbol") for c in candidates}
         # map current symbols to item ids so we can update or remove rows
         existing_rows = {
-            self.tree.set(iid, "symbol").replace("★ ", ""): iid
+            self.tree.set(iid, "symbol"): iid
             for iid in self.tree.get_children()
         }
-        for p in pairs:
+        # sort pairs by score desc so best appear on top
+        pairs_sorted = sorted(pairs, key=lambda p: p.get("score", 0.0), reverse=True)
+        for p in pairs_sorted:
             sym = p.get("symbol", "")
-            display_sym = f"★ {sym}" if sym in cand_syms else sym
+            topb_qty = float(p.get("bid_top_qty", 0.0) or 0.0)
+            topa_qty = float(p.get("ask_top_qty", 0.0) or 0.0)
+            best_bid = float(p.get("best_bid", 0.0) or 0.0)
+            best_ask = float(p.get("best_ask", 0.0) or 0.0)
+            quote = sym.split("/")[1] if "/" in sym else ""
+            quote_usd = self.exchange._quote_to_usd(quote) or 0.0
+            buy_usd = topb_qty * best_bid * quote_usd
+            sell_usd = topa_qty * best_ask * quote_usd
             values = (
-                display_sym,
+                sym,
                 f"{p.get('score',0.0):.1f}",
                 f"{p.get('pct_change_window',0.0):+.2f}",
                 self._fmt_sats(p.get('price_last',0.0)),
-                f"{(p.get('spread_abs',0.0)/(p.get('mid',1.0) or 1.0))*1e4:.1f}",
-                f"{p.get('depth',{}).get('buy',0.0)/1000:.1f}",
-                f"{p.get('depth',{}).get('sell',0.0)/1000:.1f}",
+                f"{buy_usd:.2f}",
+                f"{sell_usd:.2f}",
                 f"{p.get('imbalance',0.5):.2f}",
             )
             item = existing_rows.pop(sym, None)
@@ -668,16 +683,22 @@ class App(tb.Window):
                 sc = 0.0
 
             tag = 'scoreLow'
-            if sc >= 90:
+            if sc >= 95:
+                tag = 'score95'
+            elif sc >= 90:
                 tag = 'score90'
             elif sc >= 80:
                 tag = 'score80'
-            elif sc >= 65:
-                tag = 'score65'
+            elif sc >= 70:
+                tag = 'score70'
             elif sc >= 60:
-                tag = 'score64'
+                tag = 'score60'
             elif sc >= 50:
-                tag = 'score59'
+                tag = 'score50'
+            elif sc >= 40:
+                tag = 'score40'
+            elif sc >= 30:
+                tag = 'score30'
 
             tags = [tag]
             if sym in cand_syms:


### PR DESCRIPTION
## Summary
- Cache candidate search to refresh every 30s
- Convert top bid/ask quantities to USD for any quote and rename to Buy Qty $ / Sell Qty $
- Scan entire exchange universe instead of BTC-only pairs

## Testing
- `python -m py_compile exchange_utils.py engine.py scoring.py ui_app.py`


------
https://chatgpt.com/codex/tasks/task_e_689f5693b584832896a4caa7081b7b22