### PR TITLE
Allow LLM patches and redesign market table

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,16 +30,21 @@ class Defaults:
 
     # Selección / ranking
     weights: Dict[str, int] = field(default_factory=lambda: {
-        "imbalance": 30,
-        "spread_over_tick_price": 20,
-        "trade_flow": 20,
-        "base_volume": 15,
-        "micro_volatility": 15,
+        "trend_w": 25,
+        "trend_d": 20,
+        "pressure": 15,
+        "flow": 12,
+        "trend_h": 10,
+        "depth": 8,
+        "trend_m": 5,
+        "momentum": 3,
+        "spread": 1,
+        "microvol": 1,
     })
     pct_window: str = "1h"  # "24h"|"1h"|"5m"
 
     # Universo / otros
-    universe_quote: str = "BTC"
+    universe_quote: str = "ALL"
     topN: int = 20  # pares que mostramos al LLM / UI
     log_dir: str = "./logs"
     initial_balance_usd: float = 10000.0

--- a/engine.py
+++ b/engine.py
@@ -8,7 +8,7 @@ from llm_client import LLMClient
 class Engine(threading.Thread):
     """
     Motor principal con modos SIM/LIVE.
-    - Snapshot del universo */BTC con WS+REST
+    - Snapshot del universo completo con WS+REST
     - LLM (OpenAI si hay clave; heurística si no)
     - Validación dura y ejecución (SIM/LIVE)
     - Razones cuando no opera
@@ -35,7 +35,9 @@ class Engine(threading.Thread):
         self._last_reasons: List[str] = []
         self._first_call_done: bool = False
         self._last_auto_ts: float = 0.0
-        self._greet_sent: bool = False
+
+        self._patch_history: List[tuple[Dict[str, Any], str]] = []
+        self._last_patch_code: str = ""
 
         os.makedirs(self.cfg.log_dir, exist_ok=True)
         self._audit_file = os.path.join(self.cfg.log_dir, "audit.csv")
@@ -49,6 +51,35 @@ class Engine(threading.Thread):
 
     def is_stopped(self) -> bool:
         return self._stop.is_set()
+
+    # --------------------- Patches LLM ---------------------
+    def apply_llm_patch(self, code: str):
+        backup: Dict[str, Any] = {}
+        local_ns: Dict[str, Any] = {}
+        try:
+            exec(code, {}, local_ns)
+            for k, v in local_ns.items():
+                backup[k] = getattr(self, k, None)
+                setattr(self, k, v)
+            self._patch_history.append((backup, code))
+            self._last_patch_code = code
+            self.ui_log(f"[LLM PATCH] aplicado: {list(local_ns.keys())}")
+        except Exception as e:
+            self.ui_log(f"[LLM PATCH] error: {e}")
+
+    def revert_last_patch(self):
+        if not self._patch_history:
+            return
+        backup, _ = self._patch_history.pop()
+        for k, v in backup.items():
+            if v is None:
+                try:
+                    delattr(self, k)
+                except Exception:
+                    pass
+            else:
+                setattr(self, k, v)
+        self.ui_log("[LLM PATCH] revertido")
 
     # --------------------- Helpers simulación ---------------------
     def _sim_queue_limit(self, sym: str, price: float, qty_usd: float, side: str) -> str:
@@ -72,9 +103,24 @@ class Engine(threading.Thread):
                 continue
             best_ask = par.get("best_ask", 0.0)
             best_bid = par.get("best_bid", 0.0)
-            if o["side"] == "buy" and best_ask and o["price"] >= best_ask:
-                self._register_fill(o, fill_price=best_ask)
-                to_close.append(oid)
+            if o["side"] == "buy":
+                # Cancel if order price is not the nearest buy to best ask
+                if best_bid and o["price"] < best_bid:
+                    self._open_orders.pop(oid, None)
+                    self._log_audit("CANCEL", sym, "buy not at top bid")
+                    continue
+                bid_qty = par.get("bid_top_qty", 0.0)
+                ask_qty = par.get("ask_top_qty", 0.0)
+                total_qty = bid_qty + ask_qty
+                if total_qty > 0:
+                    if bid_qty <= 0.1 * total_qty:
+                        self._open_orders.pop(oid, None)
+                        self._log_audit("CANCEL", sym, "bid support <=10%")
+                        continue
+                    # if bid_qty >=60% we simply continue monitoring
+                if best_ask and o["price"] >= best_ask:
+                    self._register_fill(o, fill_price=best_ask)
+                    to_close.append(oid)
             elif o["side"] == "sell" and best_bid and o["price"] <= best_bid:
                 self._register_fill(o, fill_price=best_bid)
                 to_close.append(oid)
@@ -121,59 +167,72 @@ class Engine(threading.Thread):
 
     # --------------------- Núcleo ---------------------
     def _find_candidates(self, snapshot: Dict[str, Any]) -> List[Dict[str, Any]]:
-        """Selecciona pares cuyo movimiento de 1 satoshi supera el coste de comisiones
-        y registra en el log el proceso de búsqueda."""
-        fee = float(snapshot.get("config", {}).get("fee_per_side", 0.0))
-        thr_pct = fee * 2.0 * 100.0
+        """Marca todos los pares BTC como candidatos."""
         cands: List[Dict[str, Any]] = []
-        self.ui_log(f"[ENGINE {self.name}] Buscando pares buenos (umbral {thr_pct:.4f}% basado en comisiones)")
         for p in snapshot.get("pairs", []):
-            sym = p.get("symbol", "")
-            mid = float(p.get("mid") or p.get("price_last") or 0.0)
-            tick = float(p.get("tick_size") or 1e-8)
-            tick_pct = (tick / mid * 100.0) if mid else 0.0
-            p["tick_pct"] = tick_pct
-            if tick_pct > thr_pct:
-                p["is_candidate"] = True
-                cands.append(p)
-                self.ui_log(
-                    f"[ENGINE {self.name}] {sym} tick_pct {tick_pct:.4f}% > {thr_pct:.4f}% -> candidato"
-                )
-        self.ui_log(f"[ENGINE {self.name}] Candidatos encontrados: {len(cands)}")
+            p["is_candidate"] = True
+            cands.append(p)
         return cands
 
     def build_snapshot(self) -> Dict[str, Any]:
-        universe = self.exchange.fetch_universe(self.cfg.universe_quote)[:200]
-        pairs = self.exchange.fetch_top_metrics(universe[: self.cfg.topN])
-        # Collector for selected symbols
+        universe = self.exchange.fetch_universe("BTC")
+        universe = list(dict.fromkeys(universe))[:200]
+        pairs = self.exchange.fetch_top_metrics(universe)
         try:
             self.exchange.ensure_collector([p['symbol'] for p in pairs], interval_ms=800)
         except Exception:
             pass
 
+        trends = self.exchange.fetch_trend_metrics([p['symbol'] for p in pairs])
         store = self.exchange.market_summary_for([pp['symbol'] for pp in pairs])
         for p in pairs:
             ms = store.get(p['symbol'], {})
-            # fallback a valores directos si no hay store
             mid = ms.get('mid', p.get('mid', 0.0))
             p['mid'] = mid
             p['spread_pct'] = float(ms.get('spread_pct', 0.0))
+            tr = trends.get(p['symbol'], {})
             features = {
                 "imbalance": ms.get("imbalance", p.get("imbalance", 0.5)),
                 "spread_abs": ms.get("spread_abs", abs(p.get("best_ask",0.0)-p.get("best_bid",0.0))),
                 "pct_change_window": p.get("pct_change_window", 0.0),
                 "depth_buy": ms.get("depth_buy", p.get("depth",{}).get("buy",0.0)),
                 "depth_sell": ms.get("depth_sell", p.get("depth",{}).get("sell",0.0)),
+                "best_bid_qty": ms.get("bid_top_qty", p.get("bid_top_qty",0.0)),
+                "best_ask_qty": ms.get("ask_top_qty", p.get("ask_top_qty",0.0)),
+                "trade_flow_buy_ratio": ms.get("trade_flow", {}).get("buy_ratio", p.get("trade_flow", {}).get("buy_ratio", 0.5)),
+                "mid": p.get("mid", 0.0),
                 "spread_bps": p.get("spread_bps", 0.0),
                 "tick_price_bps": p.get("tick_price_bps", 8.0),
-                "trade_flow": p.get("trade_flow", {"buy_ratio": 0.5}),
                 "base_volume": p.get("depth", {}).get("buy", 0.0) + p.get("depth", {}).get("sell", 0.0),
                 "micro_volatility": p.get("micro_volatility", 0.0),
+                "trend_w": tr.get("trend_w", 0.0),
+                "trend_d": tr.get("trend_d", 0.0),
+                "trend_h": tr.get("trend_h", 0.0),
+                "trend_m": tr.get("trend_m", 0.0),
                 "weights": self.cfg.weights,
             }
+            p['best_bid'] = ms.get('best_bid', p.get('best_bid', 0.0))
+            p['best_ask'] = ms.get('best_ask', p.get('best_ask', 0.0))
+            p['bid_top_qty'] = features['best_bid_qty']
+            p['ask_top_qty'] = features['best_ask_qty']
+            p['imbalance'] = features['imbalance']
+            p['depth'] = {"buy": features['depth_buy'], "sell": features['depth_sell']}
             p["score"] = compute_score(features)
+            tot = features['best_bid_qty'] + features['best_ask_qty']
+            p['pressure'] = features['best_bid_qty']/tot if tot else 0.0
+            p['flow'] = features.get('trade_flow_buy_ratio',0.5)
+            p['trend_w'] = features['trend_w']
+            p['trend_d'] = features['trend_d']
+            p['trend_h'] = features['trend_h']
+            p['trend_m'] = features['trend_m']
+            p['depth_buy'] = features['depth_buy']
+            p['depth_sell'] = features['depth_sell']
+            p['momentum'] = abs(features.get('pct_change_window',0.0))
+            p['spread_abs'] = features['spread_abs']
+            p['micro_volatility'] = features['micro_volatility']
 
         pairs.sort(key=lambda x: (-x.get("score", 0.0), -x.get("edge_est_bps", 0.0)))
+        pairs = pairs[: self.cfg.topN]
 
         try:
             _b = self.exchange.fetch_balances_summary()
@@ -186,13 +245,14 @@ class Engine(threading.Thread):
             self.state.balance_usd = max(self.state.balance_usd, 1000.0)
         self._sim_mark_to_market(pairs)
 
-        # ---- Selección de candidatos (antes de construir snapshot) ----
+        # ---- Selección de candidatos ----
         candidates = self._find_candidates({
             "pairs": pairs,
             "config": {"fee_per_side": self.cfg.fee_per_side},
         })
-        
-        self.ui_log(f"[ENGINE {self.name}] Evaluados {len(pairs)} pares; {len(candidates)} candidatos")
+        self.ui_log(
+            f"[ENGINE {self.name}] Evaluados {len(pairs)} pares; {len(candidates)} candidatos"
+        )
         snap = {
             "ts": int(time.time()*1000),
             "global_state": {
@@ -384,6 +444,13 @@ def _log_audit(self, event: str, sym: str, detail: str):
         return False
 
     def run(self):
+        try:
+            greet_msg = self.llm.greet("hola")
+            if greet_msg:
+                self.ui_log(f"[LLM] {greet_msg}")
+                self._last_reasons = [f"LLM: {greet_msg}"]
+        except Exception:
+            pass
         while not self.is_stopped():
             try:
                 snapshot = self.build_snapshot()
@@ -425,26 +492,22 @@ def _log_audit(self, event: str, sym: str, detail: str):
                         self._last_auto_ts = now_ms
 
                 actions: List[Dict[str, Any]] = []
+                greet_msg = ""
                 if do_call:
                     try:
                         greet_msg = self.llm.greet("hola")
                         if greet_msg:
                             self.ui_log(f"[LLM] {greet_msg}")
                     except Exception:
-                        pass
-
-                    if self._greet_sent:
-                        llm_out = self.llm.propose_actions({
-                            **snapshot,
-                            "config": {**snapshot["config"], "max_actions_per_cycle": self.cfg.llm_max_actions_per_cycle},
-                        })
-                        actions = llm_out.get("actions", [])
-                    self._greet_sent = True
+                        greet_msg = ""
 
                     llm_out = self.llm.propose_actions({
                         **snapshot,
                         "config": {**snapshot["config"], "max_actions_per_cycle": self.cfg.llm_max_actions_per_cycle},
                     })
+                    patch_code = llm_out.get("patch") or llm_out.get("patch_code")
+                    if patch_code:
+                        self.apply_llm_patch(str(patch_code))
                     actions = llm_out.get("actions", [])
 
                 valid = self.validate_actions(actions, snapshot)
@@ -455,6 +518,9 @@ def _log_audit(self, event: str, sym: str, detail: str):
                     self._last_reasons = self._compute_reasons(actions, snapshot, candidates, open_count)
                     for r in self._last_reasons:
                         self.ui_log(f"[ENGINE {self.name}] {r}")
+
+                if greet_msg:
+                    self._last_reasons.append(f"LLM: {greet_msg}")
 
                 # Empuja estado nuevo
                 self.ui_push_snapshot(self.build_snapshot())

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -35,6 +35,11 @@ class BinanceWS:
         return STREAM_URL.format(streams="/".join(parts))
 
     def start(self, symbols: List[str]):
+        symbols = sorted(set(symbols))
+        with self.s.lock:
+            if self.s.running and set(symbols) == set(self.s.symbols):
+                return
+            self.s.symbols = list(symbols)
         url = self._url(symbols)
 
         def on_message(ws, msg):
@@ -101,6 +106,8 @@ class BinanceWS:
                 ba = asks[0][0] if asks else 0.0
                 mid = (bb+ba)/2.0 if bb and ba else (bb or ba or 0.0)
                 volb = sum(q for _,q in bids[:5]); vola = sum(q for _,q in asks[:5])
+                top_bid_qty = bids[0][1] if bids else 0.0
+                top_ask_qty = asks[0][1] if asks else 0.0
                 spread = (ba-bb) if (bb and ba) else 0.0
                 imb = (volb/(volb+vola)) if (volb+vola)>0 else 0.5
                 tf_buy = float(flow.get("buy",0)); tf_sell = float(flow.get("sell",0))
@@ -109,6 +116,7 @@ class BinanceWS:
                     "best_bid": bb, "best_ask": ba, "mid": mid,
                     "spread_abs": spread, "spread_pct": (spread/mid*100.0) if mid else 0.0,
                     "depth_buy": volb, "depth_sell": vola, "imbalance": imb,
+                    "bid_top_qty": top_bid_qty, "ask_top_qty": top_ask_qty,
                     "trade_flow": {"buy_ratio": buy_ratio, "streak": int(flow.get("streak",0))},
                 }
         return out
@@ -117,7 +125,8 @@ class BinanceWS:
         return max(0.0, (time.time()*1000.0) - (self.s.last_ms or 0.0))
 
 class BinanceExchange:
-    _cached_universe: List[str] = []
+    _cached_universe: Dict[str, List[str]] = {}
+    _fee_cache: Dict[str, float] = {}
 
     def __init__(self, rate_limit=True, sandbox=False):
         self.exchange = ccxt.binance({
@@ -154,8 +163,10 @@ class BinanceExchange:
 
     # ---------- WS helpers ----------
     def ensure_collector(self, symbols: List[str], interval_ms: int = 800) -> None:
+        if not symbols:
+            return
         try:
-            self.ws.start(symbols or [])
+            self.ws.start(symbols)
         except Exception:
             pass
 
@@ -168,22 +179,36 @@ class BinanceExchange:
     def market_summary_for(self, symbols: List[str]) -> Dict[str, Dict[str, Any]]:
         return self.ws.snapshot_for(symbols)
 
+    def _safe_order_book(self, sym: str):
+        try:
+            ob = self.exchange.fetch_order_book(sym, limit=5)
+            bids = ob.get("bids", [])
+            asks = ob.get("asks", [])
+        except Exception:
+            bids, asks = [], []
+        return bids, asks
+
     # ---------- Universe + metrics ----------
-    def fetch_universe(self, quote="BTC") -> List[str]:
-        if self._cached_universe:
-            return self._cached_universe
+    def fetch_universe(self, quote: Optional[str] = "BTC") -> List[str]:
+        key = (quote or "ALL").upper()
+        if key in self._cached_universe:
+            return self._cached_universe[key]
         self.load_markets()
-        syms = []
+        syms: List[str] = []
         for s, m in self.exchange.markets.items():
             try:
-                if not m.get("active"): continue
-                if m.get("spot") is False: continue
-                if (m.get("quote") or "").upper() != quote.upper(): continue
+                if not m.get("active"):
+                    continue
+                if m.get("spot") is False:
+                    continue
+                if quote and quote.upper() != "ALL":
+                    if (m.get("quote") or "").upper() != quote.upper():
+                        continue
                 syms.append(m.get("symbol") or s)
             except Exception:
                 continue
-        self._cached_universe = sorted(list(set(syms)))
-        return self._cached_universe
+        self._cached_universe[key] = sorted(list(set(syms)))
+        return self._cached_universe[key]
 
     def fetch_top_metrics(self, symbols: List[str], limit: int = 200) -> List[Dict[str, Any]]:
         out: List[Dict[str, Any]] = []
@@ -203,10 +228,24 @@ class BinanceExchange:
             ws = (ws_snap or {}).get(sym, {})
             bb = ws.get("best_bid", t.get("bid", last) if t else 0.0) or 0.0
             ba = ws.get("best_ask", t.get("ask", last) if t else 0.0) or 0.0
-            mid = ws.get("mid") or ((bb+ba)/2.0 if (bb and ba) else last)
+            mid = ws.get("mid") or ((bb + ba) / 2.0 if (bb and ba) else last)
             spread_abs = abs(ba - bb) if (bb and ba) else 0.0
-            volb = (ws.get("depth_buy", 0.0) or 0.0); vola = (ws.get("depth_sell", 0.0) or 0.0)
-            imb = (volb / (volb + vola)) if (volb + vola) > 0 else 0.5
+            volb = ws.get("depth_buy", 0.0) or 0.0
+            vola = ws.get("depth_sell", 0.0) or 0.0
+            topb = ws.get("bid_top_qty", 0.0)
+            topa = ws.get("ask_top_qty", 0.0)
+            if (topb == 0.0 or topa == 0.0) or (volb == 0.0 or vola == 0.0):
+                bids, asks = self._safe_order_book(sym)
+                if bids:
+                    bb = float(bids[0][0])
+                    topb = float(bids[0][1])
+                    volb = sum(float(q) for _, q in bids[:5])
+                if asks:
+                    ba = float(asks[0][0])
+                    topa = float(asks[0][1])
+                    vola = sum(float(q) for _, q in asks[:5])
+                spread_abs = abs(ba - bb) if (bb and ba) else spread_abs
+            imb = (topb / (topb + topa)) if (topb + topa) > 0 else 0.5
 
             mkt = (self.exchange.markets or {}).get(sym, {})
             precision = (mkt.get("precision") or {}).get("price")
@@ -225,21 +264,26 @@ class BinanceExchange:
                             tick_size = ts
                             break
             tick_size = tick_size or 1e-8
-            out.append({
-                "symbol": sym,
-                "price_last": last or mid or 0.0,
-                "mid": mid or 0.0,
-                "best_bid": bb, "best_ask": ba,
-                "spread_abs": spread_abs,
-                "pct_change_window": float(t.get("percentage") or 0.0) if t else 0.0,
-                "depth": {"buy": volb, "sell": vola},
-                "imbalance": imb,
-                "trade_flow": ws.get("trade_flow", {"buy_ratio":0.5,"streak":0}),
-                "micro_volatility": (spread_abs / (mid or 1.0)) if mid else 0.0,
-                "tick_size": tick_size,
-                "edge_est_bps": 0.0,
-                "score": 0.0,
-            })
+            out.append(
+                {
+                    "symbol": sym,
+                    "price_last": last or mid or 0.0,
+                    "mid": mid or 0.0,
+                    "best_bid": bb,
+                    "best_ask": ba,
+                    "spread_abs": spread_abs,
+                    "pct_change_window": float(t.get("percentage") or 0.0) if t else 0.0,
+                    "depth": {"buy": volb, "sell": vola},
+                    "imbalance": imb,
+                    "bid_top_qty": topb,
+                    "ask_top_qty": topa,
+                    "trade_flow": ws.get("trade_flow", {"buy_ratio": 0.5, "streak": 0}),
+                    "micro_volatility": (spread_abs / (mid or 1.0)) if mid else 0.0,
+                    "tick_size": tick_size,
+                    "edge_est_bps": 0.0,
+                    "score": 0.0,
+                }
+            )
         return out
 
     # ---------- Quotes -> USD ----------
@@ -336,3 +380,42 @@ class BinanceExchange:
             pbtc = 0.0
 
         return float(max_btc * (pbtc or 0.0)) or float(default_usd)
+
+    # ---------- Fees ----------
+    def fee_for(self, symbol: str) -> float:
+        fee = self._fee_cache.get(symbol)
+        if fee is not None:
+            return fee
+        try:
+            info = self.exchange.fetch_trading_fees().get(symbol, {})
+            fee = float(info.get("maker", info.get("taker", 0.001)))
+        except Exception:
+            fee = float((self.exchange.markets.get(symbol, {}) or {}).get("maker", 0.001))
+        self._fee_cache[symbol] = fee
+        return fee
+
+    # ---------- Tendencias ----------
+    def fetch_trend_metrics(self, symbols: List[str]) -> Dict[str, Dict[str, float]]:
+        out: Dict[str, Dict[str, float]] = {}
+        for sym in symbols:
+            trends: Dict[str, float] = {}
+            try:
+                for tf, key, lim in [
+                    ("1w", "trend_w", 2),
+                    ("1d", "trend_d", 2),
+                    ("1h", "trend_h", 24),
+                    ("5m", "trend_m", 12),
+                ]:
+                    try:
+                        ohlcv = self.exchange.fetch_ohlcv(sym, timeframe=tf, limit=lim)
+                        if len(ohlcv) >= 2:
+                            start = float(ohlcv[0][4])
+                            end = float(ohlcv[-1][4])
+                            if start > 0:
+                                trends[key] = (end - start) / start * 100.0
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+            out[sym] = trends
+        return out

--- a/llm_client.py
+++ b/llm_client.py
@@ -58,6 +58,20 @@ class LLMClient:
                 return ""
         return ""
 
+    def ask(self, message: str) -> str:
+        if self._openai:
+            try:
+                resp = self._openai.chat.completions.create(
+                    model=self.model,
+                    messages=[{"role": "user", "content": message}],
+                    temperature=self.temp_ana,
+                    timeout=20,
+                )
+                return resp.choices[0].message.content or ""
+            except Exception:
+                return ""
+        return ""
+
     # -------------------- OpenAI --------------------
     def _propose_openai(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
         client = self._openai

--- a/scoring.py
+++ b/scoring.py
@@ -7,45 +7,72 @@ def _clamp(x, lo, hi):
 def _nz(x, eps=1e-12):
     return x if abs(x) > eps else eps
 
+def _norm_trend(pct: float) -> float:
+    return 0.5 + 0.5 * _clamp(pct / 20.0, -1.0, 1.0)
+
 def compute_score(features: Dict) -> float:
     """
-    Nuevo scoring (0..100) con normalización simple:
-    - momentum: |pct_change| en ventana (0..2% mapeado a 0..1)
-    - depth_quality: log10(1 + (depth_buy+depth_sell))
-    - ob_imbalance: favorece 0.6..0.8 compradores o 0.2..0.4 vendedores (campana)
-    - micro_volatility: penalización suave por volatilidad excesiva
-    - spread_penalty: penaliza spreads amplios frente al tick proxy
-    Pesos por defecto: momentum 30, depth 25, imbalance 20, spread 15, microvol 10
+    Calcula un score (0..100) ponderado según:
+    1. Tendencias multi‑marco (semanal, diaria, horaria, minutos).
+    2. Presión inmediata del libro de órdenes (top bid vs top ask).
+    3. Flujo de órdenes reciente (ratio de compras vs ventas).
+    4. Momentum del precio en la ventana configurada.
+    5. Profundidad agregada del libro.
+    6. Penalización por spread amplio.
+    7. Penalización por micro-volatilidad.
+    La primera consideración tiene el mayor peso y la última el menor.
     """
     pct = abs(float(features.get("pct_change_window", 0.0)))
-    # 0..2% -> 0..1
     momentum = _clamp(pct / 2.0, 0.0, 1.0)
 
     depth_buy = float(features.get("depth_buy", 0.0))
     depth_sell = float(features.get("depth_sell", 0.0))
     depth = max(0.0, depth_buy + depth_sell)
-    depth_quality = math.log10(1.0 + depth) / 6.0  # 0..~1 para rangos comunes
+    depth_quality = math.log10(1.0 + depth) / 6.0
 
-    imb = float(features.get("imbalance", 0.5))
-    # campana centrada en 0.7 y 0.3 (dos colinas); pick comprador o vendedor fuerte
-    bell = math.exp(-((imb-0.7)**2)/(2*0.07**2)) + math.exp(-((imb-0.3)**2)/(2*0.07**2))
-    ob_imbalance = _clamp(bell/2.0, 0.0, 1.0)
+    best_bid_qty = float(features.get("best_bid_qty", 0.0))
+    best_ask_qty = float(features.get("best_ask_qty", 0.0))
+    pressure_raw = best_bid_qty / _nz(best_bid_qty + best_ask_qty)
+    orderbook_pressure = _clamp(abs(pressure_raw - 0.5) * 2.0, 0.0, 1.0)
+
+    buy_ratio = float(features.get("trade_flow_buy_ratio", 0.5))
+    flow_bias = _clamp(abs(buy_ratio - 0.5) * 2.0, 0.0, 1.0)
 
     micro_vol = float(features.get("micro_volatility", 0.0))
-    # volatilidad deseable moderada: penalización por colas pesadas
     micro_vol_pen = 1.0 / (1.0 + 50.0 * micro_vol)
 
-    spread = float(features.get("spread_abs", 0.0))  # diferencia absoluta
+    spread = float(features.get("spread_abs", 0.0))
     price = abs(float(features.get("mid", 0.0)))
-    tick = max(price * 1e-6, 1e-8)  # proxy
+    tick = max(price * 1e-6, 1e-8)
     spread_penalty = 1.0 / (1.0 + (spread / _nz(tick)))
 
-    w = features.get("weights") or {"momentum":30, "depth":25, "imbalance":20, "spread":15, "microvol":10}
+    trend_w = _norm_trend(float(features.get("trend_w", 0.0)))
+    trend_d = _norm_trend(float(features.get("trend_d", 0.0)))
+    trend_h = _norm_trend(float(features.get("trend_h", 0.0)))
+    trend_m = _norm_trend(float(features.get("trend_m", 0.0)))
+
+    w = features.get("weights") or {
+        "trend_w": 25,
+        "trend_d": 20,
+        "pressure": 15,
+        "flow": 12,
+        "trend_h": 10,
+        "depth": 8,
+        "trend_m": 5,
+        "momentum": 3,
+        "spread": 1,
+        "microvol": 1,
+    }
     score = (
-        momentum * w.get("momentum",30) +
-        depth_quality * w.get("depth",25) +
-        ob_imbalance * w.get("imbalance",20) +
-        spread_penalty * w.get("spread",15) +
-        micro_vol_pen * w.get("microvol",10)
-    ) / 1.0
+        trend_w * w.get("trend_w", 0) +
+        trend_d * w.get("trend_d", 0) +
+        orderbook_pressure * w.get("pressure", 0) +
+        flow_bias * w.get("flow", 0) +
+        trend_h * w.get("trend_h", 0) +
+        depth_quality * w.get("depth", 0) +
+        trend_m * w.get("trend_m", 0) +
+        momentum * w.get("momentum", 0) +
+        spread_penalty * w.get("spread", 0) +
+        micro_vol_pen * w.get("microvol", 0)
+    )
     return float(_clamp(score, 0.0, 100.0))

--- a/ui_app.py
+++ b/ui_app.py
@@ -6,6 +6,7 @@ from tkinter import ttk
 from typing import Dict, Any, List
 from config import UIColors, Defaults, AppState
 from engine import Engine
+from scoring import compute_score
 
 BADGE_SIM = "🔧SIM"
 BADGE_LIVE = "⚡LIVE"
@@ -63,7 +64,7 @@ class App(tb.Window):
         return str(sats)
 
     def _coerce(self, val: str, col: str):
-        v = str(val).replace("★ ", "")
+        v = str(val)
         if col == "symbol":
             return v
         if col == "price_sats":
@@ -102,24 +103,29 @@ class App(tb.Window):
         self._engine_live: Engine | None = None
         self.exchange = None
 
+        self.metric_defaults = dict(self.cfg.weights)
+        self.metric_vars: Dict[str, tb.BooleanVar] = {}
+
         self._keys_file = os.path.join(os.path.dirname(__file__), ".api_keys.json")
 
         self._build_ui()
         self._load_saved_keys()
         self._lock_controls(True)
         self.after(250, self._poll_log_queue)
-        self.after(500, self._tick_ui_refresh)
+        self.after(4000, self._tick_ui_refresh)
         # Precarga de mercado y balance
         self._warmup_thread = threading.Thread(target=self._warmup_load_market, daemon=True)
         self._warmup_thread.start()
         self.after(2000, self._tick_balance_refresh)
+        self._last_cand_refresh = 0.0
 
     # ------------------- UI -------------------
     def _build_ui(self):
         # Grid principal
         self.columnconfigure(0, weight=3)
         self.columnconfigure(1, weight=2)
-        self.rowconfigure(1, weight=1)
+        self.rowconfigure(1, weight=2)
+        self.rowconfigure(2, weight=1)
         try:
             self._ensure_exchange()
         except Exception:
@@ -150,62 +156,66 @@ class App(tb.Window):
         self.lbl_pnl.grid(row=1, column=2, sticky="e", padx=5)
         self.lbl_bal.grid(row=1, column=3, sticky="e", padx=5)
 
-        # Left panes
-        left = ttk.Frame(self, padding=(10, 0, 10, 10))
-        left.grid(row=1, column=0, sticky="nsew")
-        left.rowconfigure(0, weight=2)
-        left.rowconfigure(1, weight=1)
-        left.rowconfigure(2, weight=1)
-        left.columnconfigure(0, weight=1)
-
-        # Mercado
-        frm_mkt = ttk.Labelframe(left, text="Mercado", padding=6)
-        frm_mkt.grid(row=0, column=0, sticky="nsew", pady=(0,8))
+        # Mercado (full width)
+        frm_mkt = ttk.Labelframe(self, text="Mercado", padding=6)
+        frm_mkt.grid(row=1, column=0, columnspan=2, sticky="nsew", padx=(10,10), pady=(0,8))
         frm_mkt.rowconfigure(0, weight=1); frm_mkt.columnconfigure(0, weight=1)
         cols = (
-            "symbol",
-            "score",
-            "pct",
-            "price_sats",
-            "spread_bps",
-            "buy_k",
-            "sell_k",
-            "imb",
+            "symbol","score","pct","price_sats",
+            "trend_w","trend_d","trend_h","trend_m",
+            "pressure","flow","depth_buy","depth_sell",
+            "momentum","spread","micro_vol",
         )
         self.tree = ttk.Treeview(frm_mkt, columns=cols, show="headings")
         style = tb.Style(); style.configure("Treeview", font=("Consolas", 10))
         self._sort_col: str | None = None
         self._sort_reverse: bool = False
         headers = [
-            ("symbol", "Símbolo", 160, "w"),
+            ("symbol", "Símbolo", 150, "w"),
             ("score", "Score", 70, "e"),
             ("pct", "%24h", 70, "e"),
             ("price_sats", "Precio (sats)", 120, "e"),
-            ("spread_bps", "Spread(bps)", 100, "e"),
-            ("buy_k", "Buy k", 80, "e"),
-            ("sell_k", "Sell k", 80, "e"),
-            ("imb", "Imb", 70, "e"),
+            ("trend_w", "Trend W", 90, "e"),
+            ("trend_d", "Trend D", 90, "e"),
+            ("trend_h", "Trend H", 90, "e"),
+            ("trend_m", "Trend M", 90, "e"),
+            ("pressure", "Presión", 90, "e"),
+            ("flow", "Flujo", 90, "e"),
+            ("depth_buy", "DepthBuy", 90, "e"),
+            ("depth_sell", "DepthSell", 90, "e"),
+            ("momentum", "Momentum", 90, "e"),
+            ("spread", "Spread", 90, "e"),
+            ("micro_vol", "MicroVol", 90, "e"),
         ]
         for c, txt, w, an in headers:
             self.tree.heading(c, text=txt, command=lambda col=c: self._sort_tree(col, False))
-            self.tree.column(c, width=w, anchor=an, stretch=False)
+            self.tree.column(c, width=w, anchor=an, stretch=True)
         vsb = ttk.Scrollbar(frm_mkt, orient="vertical", command=self.tree.yview)
         self.tree.configure(yscrollcommand=vsb.set)
         self.tree.grid(row=0, column=0, sticky="nsew"); vsb.grid(row=0, column=1, sticky="ns")
-        # Colores por score (fino)
-        self.tree.tag_configure('score90', background='#0e7a3b')
-        self.tree.tag_configure('score80', background='#16a34a')
-        self.tree.tag_configure('score65', background='#22c55e')
-        self.tree.tag_configure('score64', background='#ffd24d')
-        self.tree.tag_configure('score59', background='#f59e0b')
-        self.tree.tag_configure('score50', background='#fbbf24')
-        self.tree.tag_configure('scoreLow', background='#9ca3af')
+        # Colores por score (fino) en texto
+        self.tree.tag_configure('score95', foreground='#166534')
+        self.tree.tag_configure('score90', foreground='#15803d')
+        self.tree.tag_configure('score80', foreground='#16a34a')
+        self.tree.tag_configure('score70', foreground='#22c55e')
+        self.tree.tag_configure('score60', foreground='#84cc16')
+        self.tree.tag_configure('score50', foreground='#eab308')
+        self.tree.tag_configure('score40', foreground='#f97316')
+        self.tree.tag_configure('score30', foreground='#f43f5e')
+        self.tree.tag_configure('scoreLow', foreground='#b91c1c')
         self.tree.tag_configure('veto', background='#ef4444', foreground='white')
         self.tree.tag_configure('candidate', font=('Consolas', 10, 'bold'))
 
+        # Panel inferior izquierdo para órdenes
+        left = ttk.Frame(self, padding=(10,0,10,10))
+        left.grid(row=2, column=0, sticky="nsew")
+        left.rowconfigure(0, weight=1)
+        left.rowconfigure(1, weight=1)
+        left.columnconfigure(0, weight=1)
+
         # Órdenes abiertas
         frm_open = ttk.Labelframe(left, text="Órdenes abiertas", padding=6)
-        frm_open.grid(row=1, column=0, sticky="nsew", pady=(0,8))
+        frm_open.grid(row=0, column=0, sticky="nsew", pady=(0,8))
         frm_open.rowconfigure(0, weight=1); frm_open.columnconfigure(0, weight=1)
         cols_o = ("id","symbol","side","mode","price","qty_usd","age")
         self.tree_open = ttk.Treeview(frm_open, columns=cols_o, show="headings")
@@ -216,14 +226,14 @@ class App(tb.Window):
                                ("price","Precio",120,"e"),
                                ("qty_usd","USD",100,"e"),
                                ("age","Edad(s)",80,"e")]:
-            self.tree_open.heading(c, text=txt); self.tree_open.column(c, width=w, anchor=an, stretch=False)
+            self.tree_open.heading(c, text=txt); self.tree_open.column(c, width=w, anchor=an, stretch=True)
         vsb2 = ttk.Scrollbar(frm_open, orient="vertical", command=self.tree_open.yview)
         self.tree_open.configure(yscrollcommand=vsb2.set)
         self.tree_open.grid(row=0, column=0, sticky="nsew"); vsb2.grid(row=0, column=1, sticky="ns")
 
         # Órdenes cerradas
         frm_closed = ttk.Labelframe(left, text="Órdenes cerradas", padding=6)
-        frm_closed.grid(row=2, column=0, sticky="nsew")
+        frm_closed.grid(row=1, column=0, sticky="nsew")
         frm_closed.rowconfigure(0, weight=1); frm_closed.columnconfigure(0, weight=1)
         cols_c = ("ts","symbol","side","mode","price","qty_usd")
         self.tree_closed = ttk.Treeview(frm_closed, columns=cols_c, show="headings")
@@ -233,15 +243,19 @@ class App(tb.Window):
                                ("mode","Modo",80,"w"),
                                ("price","Precio",120,"e"),
                                ("qty_usd","USD",100,"e")]:
-            self.tree_closed.heading(c, text=txt); self.tree_closed.column(c, width=w, anchor=an, stretch=False)
+            self.tree_closed.heading(c, text=txt); self.tree_closed.column(c, width=w, anchor=an, stretch=True)
         vsb3 = ttk.Scrollbar(frm_closed, orient="vertical", command=self.tree_closed.yview)
         self.tree_closed.configure(yscrollcommand=vsb3.set)
         self.tree_closed.grid(row=0, column=0, sticky="nsew"); vsb3.grid(row=0, column=1, sticky="ns")
 
         # Right panel
         right = ttk.Frame(self, padding=(0, 0, 10, 10))
-        right.grid(row=1, column=1, sticky="nsew")
+        right.grid(row=2, column=1, sticky="nsew")
         right.columnconfigure(0, weight=1)
+        right.rowconfigure(4, weight=0)
+        right.rowconfigure(5, weight=1)
+        right.rowconfigure(6, weight=0)
+        right.rowconfigure(7, weight=1)
 
         ttk.Label(right, text="Ajustes").grid(row=0, column=0, sticky="w", pady=(0,6))
 
@@ -288,33 +302,57 @@ class App(tb.Window):
         ttk.Entry(frm_llm, textvariable=self.var_llm_secs, width=14).grid(row=1, column=1, sticky="e")
         ttk.Button(frm_llm, text="Aplicar LLM", command=self._apply_llm).grid(row=0, column=2, rowspan=2, padx=6)
 
-        # Estado
-        st = ttk.Labelframe(right, text="Estado", padding=8)
-        st.grid(row=4, column=0, sticky="ew", pady=6)
-        self.lbl_ws = ttk.Label(st, text="WS: 0 ms")
-        self.lbl_rest = ttk.Label(st, text="REST: 0 ms")
-        self.lbl_ws.grid(row=0, column=0, sticky="w")
-        self.lbl_rest.grid(row=0, column=1, sticky="e")
+        # Consulta LLM
+        frm_llm_manual = ttk.Labelframe(right, text="Consulta LLM", padding=8)
+        frm_llm_manual.grid(row=4, column=0, sticky="nsew")
+        frm_llm_manual.columnconfigure(0, weight=1)
+        self.var_llm_query = tb.StringVar()
+        ttk.Entry(frm_llm_manual, textvariable=self.var_llm_query).grid(row=0, column=0, sticky="ew")
+        ttk.Button(frm_llm_manual, text="Enviar", command=self._send_llm_query).grid(row=0, column=1, padx=4)
+        frm_llm_manual.rowconfigure(1, weight=1)
+        self.txt_llm_resp = ScrolledText(frm_llm_manual, height=3, autohide=True, wrap="word")
+        self.txt_llm_resp.grid(row=1, column=0, columnspan=2, sticky="nsew")
 
-        # Info / razones
+        # Información / Razones
         frm_info = ttk.Labelframe(right, text="Información / Razones", padding=8)
-        frm_info.grid(row=5, column=0, sticky="nsew", pady=6)
-        frm_info.rowconfigure(0, weight=1); frm_info.columnconfigure(0, weight=1)
-        self.txt_info = ScrolledText(frm_info, height=12, autohide=True, wrap="word")
-        self.txt_info.grid(row=0, column=0, sticky="nsew")
+        frm_info.grid(row=5, column=0, sticky="nsew", pady=(6, 0))
+        frm_info.rowconfigure(0, weight=1); frm_info.columnconfigure(0, weight=1); frm_info.columnconfigure(1, weight=1)
+        self.txt_info = ScrolledText(frm_info, height=6, autohide=True, wrap="word")
+        self.txt_info.grid(row=0, column=0, columnspan=2, sticky="nsew")
+        ttk.Button(frm_info, text="Revertir patch", command=self._revert_patch).grid(row=1, column=0, sticky="ew", pady=(4,0))
+        ttk.Button(frm_info, text="Patch a LIVE", command=self._apply_patch_live).grid(row=1, column=1, sticky="ew", pady=(4,0))
 
-        # Footer log
-        footer = ttk.Labelframe(self, text="Log", padding=10)
-        footer.grid(row=2, column=0, columnspan=2, sticky="ew")
-        footer.columnconfigure(0, weight=1)
-        self.txt_log = ScrolledText(footer, height=6, autohide=True, wrap="none")
-        self.txt_log.grid(row=0, column=0, sticky="ew")
+        # Métricas de Score
+        frm_met = ttk.Labelframe(right, text="Métricas Score", padding=8)
+        frm_met.grid(row=6, column=0, sticky="ew", pady=6)
+        for idx, (key, label) in enumerate([
+            ("trend_w", "Trend semanal"),
+            ("trend_d", "Trend diaria"),
+            ("pressure", "Presión libro"),
+            ("flow", "Flujo órdenes"),
+            ("trend_h", "Trend horas"),
+            ("depth", "Profundidad"),
+            ("trend_m", "Trend minutos"),
+            ("momentum", "Momentum"),
+            ("spread", "Spread"),
+            ("microvol", "Microvol"),
+        ]):
+            var = tb.BooleanVar(value=self.cfg.weights.get(key, 0) > 0)
+            self.metric_vars[key] = var
+            ttk.Checkbutton(frm_met, text=label, variable=var, command=self._apply_metric_weights).grid(row=idx//2, column=idx%2, sticky="w")
+
+        # Log
+        frm_log = ttk.Labelframe(right, text="Log", padding=8)
+        frm_log.grid(row=7, column=0, sticky="nsew", pady=6)
+        frm_log.rowconfigure(0, weight=1); frm_log.columnconfigure(0, weight=1)
+        self.txt_log = ScrolledText(frm_log, height=6, autohide=True, wrap="none")
+        self.txt_log.grid(row=0, column=0, sticky="nsew")
 
         # Bindings
         self.var_bot_sim.trace_add("write", self._on_bot_sim)
         self.var_bot_live.trace_add("write", self._on_bot_live)
         self.var_live_confirm.trace_add("write", self._on_live_confirm)
-        self.tree.bind("<<TreeviewSelect>>", lambda e: self._update_min_marker())
+        self.tree.bind("<<TreeviewSelect>>", self._on_pair_select)
 
     # ------------------- Helpers -------------------
     def _ensure_exchange(self):
@@ -351,6 +389,42 @@ class App(tb.Window):
             uni = self.exchange.fetch_universe("BTC")[:100]
             if uni:
                 pairs = self.exchange.fetch_top_metrics(uni[: min(20, len(uni))])
+                try:
+                    self.exchange.ensure_collector([p['symbol'] for p in pairs], interval_ms=800)
+                except Exception:
+                    pass
+                store = self.exchange.market_summary_for([p['symbol'] for p in pairs])
+                trends = self.exchange.fetch_trend_metrics([p['symbol'] for p in pairs])
+                for p in pairs:
+                    ms = store.get(p['symbol'], {})
+                    tr = trends.get(p['symbol'], {})
+                    features = {
+                        "imbalance": ms.get("imbalance", p.get("imbalance", 0.5)),
+                        "spread_abs": ms.get("spread_abs", abs(p.get("best_ask",0.0)-p.get("best_bid",0.0))),
+                        "pct_change_window": p.get("pct_change_window", 0.0),
+                        "depth_buy": ms.get("depth_buy", p.get("depth",{}).get("buy",0.0)),
+                        "depth_sell": ms.get("depth_sell", p.get("depth",{}).get("sell",0.0)),
+                        "best_bid_qty": ms.get("bid_top_qty", p.get("bid_top_qty",0.0)),
+                        "best_ask_qty": ms.get("ask_top_qty", p.get("ask_top_qty",0.0)),
+                        "trade_flow_buy_ratio": ms.get("trade_flow", {}).get("buy_ratio", p.get("trade_flow", {}).get("buy_ratio", 0.5)),
+                        "mid": ms.get("mid", p.get("mid",0.0)),
+                        "spread_bps": p.get("spread_bps", 0.0),
+                        "tick_price_bps": p.get("tick_price_bps", 8.0),
+                        "base_volume": p.get("depth", {}).get("buy", 0.0) + p.get("depth", {}).get("sell", 0.0),
+                        "micro_volatility": p.get("micro_volatility", 0.0),
+                        "trend_w": tr.get("trend_w", 0.0),
+                        "trend_d": tr.get("trend_d", 0.0),
+                        "trend_h": tr.get("trend_h", 0.0),
+                        "trend_m": tr.get("trend_m", 0.0),
+                        "weights": self.cfg.weights,
+                    }
+                    p['best_bid'] = ms.get('best_bid', p.get('best_bid',0.0))
+                    p['best_ask'] = ms.get('best_ask', p.get('best_ask',0.0))
+                    p['bid_top_qty'] = features['best_bid_qty']
+                    p['ask_top_qty'] = features['best_ask_qty']
+                    p['imbalance'] = features['imbalance']
+                    p['depth'] = {"buy": features['depth_buy'], "sell": features['depth_sell']}
+                    p['score'] = compute_score(features)
                 if not self._snapshot:
                     self._refresh_market_table(pairs, [])
             # Mínimo global BTC en el marcador
@@ -369,22 +443,60 @@ class App(tb.Window):
             if not uni:
                 return
             pairs = self.exchange.fetch_top_metrics(uni[: min(20, len(uni))])
-            fee = float(self.cfg.fee_per_side)
-            thr_pct = fee * 2.0 * 100.0
+            try:
+                self.exchange.ensure_collector([p['symbol'] for p in pairs], interval_ms=800)
+            except Exception:
+                pass
+            store = self.exchange.market_summary_for([p['symbol'] for p in pairs])
+            trends = self.exchange.fetch_trend_metrics([p['symbol'] for p in pairs])
             cands: List[Dict[str, Any]] = []
-            self.log_append(f"[ENGINE] Buscando pares buenos (umbral {thr_pct:.4f}% basado en comisiones)")
             for p in pairs:
-                sym = p.get("symbol", "")
-                mid = float(p.get("mid") or p.get("price_last") or 0.0)
-                tick = float(p.get("tick_size") or 1e-8)
-                tick_pct = (tick / mid * 100.0) if mid else 0.0
-                p["tick_pct"] = tick_pct
-                if tick_pct > thr_pct:
-                    p["is_candidate"] = True
-                    cands.append(p)
-                    self.log_append(f"[ENGINE] {sym} tick_pct {tick_pct:.4f}% > {thr_pct:.4f}% -> candidato")
-            self.log_append(f"[ENGINE] Candidatos encontrados: {len(cands)}")
-            self._snapshot = {**self._snapshot, "pairs": pairs, "candidates": cands}
+                ms = store.get(p['symbol'], {})
+                tr = trends.get(p['symbol'], {})
+                features = {
+                    "imbalance": ms.get("imbalance", p.get("imbalance", 0.5)),
+                    "spread_abs": ms.get("spread_abs", abs(p.get("best_ask",0.0)-p.get("best_bid",0.0))),
+                    "pct_change_window": p.get("pct_change_window", 0.0),
+                    "depth_buy": ms.get("depth_buy", p.get("depth",{}).get("buy",0.0)),
+                    "depth_sell": ms.get("depth_sell", p.get("depth",{}).get("sell",0.0)),
+                    "best_bid_qty": ms.get("bid_top_qty", p.get("bid_top_qty",0.0)),
+                    "best_ask_qty": ms.get("ask_top_qty", p.get("ask_top_qty",0.0)),
+                    "trade_flow_buy_ratio": ms.get("trade_flow", {}).get("buy_ratio", p.get("trade_flow", {}).get("buy_ratio", 0.5)),
+                    "mid": ms.get("mid", p.get("mid",0.0)),
+                    "spread_bps": p.get("spread_bps", 0.0),
+                    "tick_price_bps": p.get("tick_price_bps", 8.0),
+                    "base_volume": p.get("depth", {}).get("buy", 0.0) + p.get("depth", {}).get("sell", 0.0),
+                    "micro_volatility": p.get("micro_volatility", 0.0),
+                    "trend_w": tr.get("trend_w", 0.0),
+                    "trend_d": tr.get("trend_d", 0.0),
+                    "trend_h": tr.get("trend_h", 0.0),
+                    "trend_m": tr.get("trend_m", 0.0),
+                    "weights": self.cfg.weights,
+                }
+                p['best_bid'] = ms.get('best_bid', p.get('best_bid',0.0))
+                p['best_ask'] = ms.get('best_ask', p.get('best_ask',0.0))
+                p['bid_top_qty'] = features['best_bid_qty']
+                p['ask_top_qty'] = features['best_ask_qty']
+                p['imbalance'] = features['imbalance']
+                p['depth'] = {"buy": features['depth_buy'], "sell": features['depth_sell']}
+                p['score'] = compute_score(features)
+                tot = features['best_bid_qty'] + features['best_ask_qty']
+                p['pressure'] = features['best_bid_qty']/tot if tot else 0.0
+                p['flow'] = features.get('trade_flow_buy_ratio',0.5)
+                p['trend_w'] = features['trend_w']
+                p['trend_d'] = features['trend_d']
+                p['trend_h'] = features['trend_h']
+                p['trend_m'] = features['trend_m']
+                p['depth_buy'] = features['depth_buy']
+                p['depth_sell'] = features['depth_sell']
+                p['momentum'] = abs(features.get('pct_change_window',0.0))
+                p['spread_abs'] = features['spread_abs']
+                p['micro_volatility'] = features['micro_volatility']
+                p['is_candidate'] = True
+                cands.append(p)
+            cands.sort(key=lambda x: x.get('score',0.0), reverse=True)
+            if not ((self._engine_sim and self._engine_sim.is_alive()) or (self._engine_live and self._engine_live.is_alive())):
+                self._snapshot = {**self._snapshot, "pairs": pairs, "candidates": cands}
             self._refresh_market_table(pairs, cands)
         except Exception as e:
             self.log_append(f"[ENGINE] Error al refrescar mercado: {e}")
@@ -550,6 +662,52 @@ class App(tb.Window):
             self._engine_live._last_loop_ts = time.monotonic()
         self.log_append("[LLM] Configuración aplicada.")
 
+    def _apply_metric_weights(self):
+        for key, var in self.metric_vars.items():
+            self.cfg.weights[key] = self.metric_defaults.get(key, 0) if var.get() else 0
+        if self._engine_sim:
+            self._engine_sim.cfg.weights = dict(self.cfg.weights)
+        if self._engine_live:
+            self._engine_live.cfg.weights = dict(self.cfg.weights)
+        threading.Thread(target=self._refresh_market_candidates, daemon=True).start()
+
+    def _send_llm_query(self):
+        q = self.var_llm_query.get().strip()
+        if not q:
+            return
+        def worker():
+            eng = self._engine_live or self._engine_sim
+            resp = ""
+            if eng and eng.llm:
+                resp = eng.llm.ask(q)
+            else:
+                try:
+                    from llm_client import LLMClient
+                    llm = LLMClient(model=self.var_llm_model.get(), api_key=self.var_oai_key.get())
+                    resp = llm.ask(q)
+                except Exception:
+                    resp = ""
+            def update():
+                self.txt_llm_resp.delete("1.0", "end")
+                self.txt_llm_resp.insert("end", resp or "[sin respuesta]")
+                lines = int(self.txt_llm_resp.index('end-1c').split('.')[0])
+                self.txt_llm_resp.configure(height=min(10, max(3, lines)))
+            self.after(0, update)
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _revert_patch(self):
+        if self._engine_sim:
+            self._engine_sim.revert_last_patch()
+        if self._engine_live:
+            self._engine_live.revert_last_patch()
+        self.log_append("[LLM] Patches revertidos.")
+
+    def _apply_patch_live(self):
+        if self._engine_sim and self._engine_live and getattr(self._engine_sim, "_last_patch_code", ""):
+            code = self._engine_sim._last_patch_code
+            self._engine_live.apply_llm_patch(code)
+            self.log_append("[LLM] Patch aplicado al LIVE.")
+
     def _apply_sizes(self):
         # SIM: editable
         try:
@@ -615,17 +773,15 @@ class App(tb.Window):
         try:
             if pnlu >= 0: self.lbl_pnl.configure(bootstyle=SUCCESS)
             else: self.lbl_pnl.configure(bootstyle=DANGER)
-        except Exception: pass
-        self.lbl_rest.configure(text=f"REST: {gs.get('latency_rest_ms',0):.0f} ms")
-        self.lbl_ws.configure(text=f"WS: {gs.get('latency_ws_ms',0):.0f} ms")
+        except Exception:
+            pass
 
         # Tablas
         self._refresh_market_table(
             snap.get("pairs", []),
             snap.get("candidates", []),
         )
-        self._refresh_open_orders(snap.get("open_orders", []))
-        self._refresh_closed_orders(snap.get("closed_orders", []))
+        threading.Thread(target=self._refresh_market_candidates, daemon=True).start()
 
         # Razones
         reasons = snap.get("reasons", [])
@@ -635,27 +791,47 @@ class App(tb.Window):
                 self.txt_info.insert("end", f"• {r}\n")
                 self.log_append(f"[ENGINE] {r}")
 
-        self.after(500, self._tick_ui_refresh)
+        self.after(4000, self._tick_ui_refresh)
+
+    def _tick_open_orders(self):
+        snap = self._snapshot or {}
+        self._refresh_open_orders(snap.get("open_orders", []))
+        self.after(4000, self._tick_open_orders)
+
+    def _tick_closed_orders(self):
+        snap = self._snapshot or {}
+        self._refresh_closed_orders(snap.get("closed_orders", []))
+        self.after(4000, self._tick_closed_orders)
+
+    def _on_pair_select(self, _event):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        self.after(300, lambda: [self.tree.selection_remove(i) for i in sel])
 
     def _refresh_market_table(self, pairs: List[Dict[str, Any]], candidates: List[Dict[str, Any]]):
         cand_syms = {c.get("symbol") for c in candidates}
-        # map current symbols to item ids so we can update or remove rows
-        existing_rows = {
-            self.tree.set(iid, "symbol").replace("★ ", ""): iid
-            for iid in self.tree.get_children()
-        }
-        for p in pairs:
+        pairs = list(pairs)
+        existing_rows = {self.tree.set(iid, "symbol"): iid for iid in self.tree.get_children()}
+        pairs_sorted = sorted(pairs, key=lambda p: p.get("score", 0.0), reverse=True)
+        for p in pairs_sorted:
             sym = p.get("symbol", "")
-            display_sym = f"★ {sym}" if sym in cand_syms else sym
             values = (
-                display_sym,
+                sym,
                 f"{p.get('score',0.0):.1f}",
                 f"{p.get('pct_change_window',0.0):+.2f}",
-                self._fmt_sats(p.get('price_last',0.0)),
-                f"{(p.get('spread_abs',0.0)/(p.get('mid',1.0) or 1.0))*1e4:.1f}",
-                f"{p.get('depth',{}).get('buy',0.0)/1000:.1f}",
-                f"{p.get('depth',{}).get('sell',0.0)/1000:.1f}",
-                f"{p.get('imbalance',0.5):.2f}",
+                self._fmt_sats(p.get('mid',0.0)),
+                f"{p.get('trend_w',0.0):+.2f}",
+                f"{p.get('trend_d',0.0):+.2f}",
+                f"{p.get('trend_h',0.0):+.2f}",
+                f"{p.get('trend_m',0.0):+.2f}",
+                f"{p.get('pressure',0.0):.2f}",
+                f"{p.get('flow',0.0):.2f}",
+                f"{p.get('depth_buy',0.0):.2f}",
+                f"{p.get('depth_sell',0.0):.2f}",
+                f"{p.get('momentum',0.0):.2f}",
+                f"{p.get('spread_abs',0.0):.8f}",
+                f"{p.get('micro_volatility',0.0):.4f}",
             )
             item = existing_rows.pop(sym, None)
             if item:
@@ -668,16 +844,22 @@ class App(tb.Window):
                 sc = 0.0
 
             tag = 'scoreLow'
-            if sc >= 90:
+            if sc >= 95:
+                tag = 'score95'
+            elif sc >= 90:
                 tag = 'score90'
             elif sc >= 80:
                 tag = 'score80'
-            elif sc >= 65:
-                tag = 'score65'
+            elif sc >= 70:
+                tag = 'score70'
             elif sc >= 60:
-                tag = 'score64'
+                tag = 'score60'
             elif sc >= 50:
-                tag = 'score59'
+                tag = 'score50'
+            elif sc >= 40:
+                tag = 'score40'
+            elif sc >= 30:
+                tag = 'score30'
 
             tags = [tag]
             if sym in cand_syms:


### PR DESCRIPTION
## Summary
- Stabilize Binance WebSocket collector to keep order-book metrics populated
- Filter universe to BTC pairs only and start collectors once per symbol set
- Move patch controls to info panel and refresh metrics asynchronously to avoid UI freezes
- Stop logging pair search spam

## Testing
- `python -m py_compile exchange_utils.py engine.py scoring.py ui_app.py llm_client.py`


------
https://chatgpt.com/codex/tasks/task_e_689f5693b584832896a4caa7081b7b22