### PR TITLE
Mejoras en control de ciclo de testeos

### DIFF
--- a/test_manager.py
+++ b/test_manager.py
@@ -1,14 +1,23 @@
-import threading, random
+import threading, time, copy
 from typing import Callable, List, Dict, Optional
+from engine import Engine
 
 class TestManager(threading.Thread):
     """Runs iterative testing cycles for strategy variations."""
-    def __init__(self, cfg, llm, log: Callable[[str], None], info: Callable[[str], None]):
+    def __init__(
+        self,
+        cfg,
+        llm,
+        log: Callable[[str], None],
+        info: Callable[[str], None],
+        min_orders: int = 50,
+    ):
         super().__init__(daemon=True)
         self.cfg = cfg
         self.llm = llm
         self.log = log
         self.info = info
+        self.min_orders = int(min_orders)
         self._stop = threading.Event()
         self.winner_thr: Optional[float] = None
 
@@ -26,16 +35,26 @@ class TestManager(threading.Thread):
                 self.info(f"Bot {i + 1}: opportunity_threshold_percent={thr:.4f}")
 
             for v in variants:
-                pnl = 0.0
-                buys = sells = 0
-                while buys < 50 or sells < 50:
-                    change = random.uniform(-0.5, 0.5) + (v["thr"] - base)
-                    pnl += change
-                    if random.random() > 0.5 and buys < 50:
-                        buys += 1
-                    elif sells < 50:
-                        sells += 1
-                v["pnl"] = pnl
+                if self._stop.is_set():
+                    break
+                cfg_copy = copy.deepcopy(self.cfg)
+                cfg_copy.opportunity_threshold_percent = v["thr"]
+                eng = Engine(ui_push_snapshot=lambda _: None, ui_log=self.log, name=f"TEST-{v['id']}")
+                eng.cfg = cfg_copy
+                eng.mode = "SIM"
+                eng.llm = self.llm
+                eng.start()
+                start = time.time()
+                while not self._stop.is_set() and len(eng._closed_orders) < self.min_orders:
+                    time.sleep(1)
+                    if time.time() - start > 300:
+                        break
+                v["pnl"] = eng.state.pnl_intraday_percent
+                eng.stop()
+                try:
+                    eng.join(timeout=5)
+                except Exception:
+                    pass
 
             summary = "\n".join(
                 [f"Bot {v['id']}: thr={v['thr']:.4f}, pnl={v['pnl']:.2f}" for v in variants]


### PR DESCRIPTION
## Summary
- Permite definir órdenes mínimas antes de evaluar estrategias
- Botón de inicio de testeos ahora arranca/parar ciclo y motor SIM automáticamente
- El gestor de tests ejecuta variaciones reales del motor hasta alcanzar las órdenes mínimas

## Testing
- `python -m py_compile ui_app.py test_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68a06bcc267883288321ccc0307b2638