### PR TITLE
Mejoras en control de ciclo de testeos

### DIFF
--- a/test_manager.py
+++ b/test_manager.py
@@ -1,14 +1,23 @@
-import threading, random
+import threading, time, copy
 from typing import Callable, List, Dict, Optional
+from engine import Engine
 
 class TestManager(threading.Thread):
     """Runs iterative testing cycles for strategy variations."""
-    def __init__(self, cfg, llm, log: Callable[[str], None], info: Callable[[str], None]):
+    def __init__(
+        self,
+        cfg,
+        llm,
+        log: Callable[[str], None],
+        info: Callable[[str], None],
+        min_orders: int = 50,
+    ):
         super().__init__(daemon=True)
         self.cfg = cfg
         self.llm = llm
         self.log = log
         self.info = info
+        self.min_orders = int(min_orders)
         self._stop = threading.Event()
         self.winner_thr: Optional[float] = None
 
@@ -26,16 +35,26 @@ class TestManager(threading.Thread):
                 self.info(f"Bot {i + 1}: opportunity_threshold_percent={thr:.4f}")
 
             for v in variants:
-                pnl = 0.0
-                buys = sells = 0
-                while buys < 50 or sells < 50:
-                    change = random.uniform(-0.5, 0.5) + (v["thr"] - base)
-                    pnl += change
-                    if random.random() > 0.5 and buys < 50:
-                        buys += 1
-                    elif sells < 50:
-                        sells += 1
-                v["pnl"] = pnl
+                if self._stop.is_set():
+                    break
+                cfg_copy = copy.deepcopy(self.cfg)
+                cfg_copy.opportunity_threshold_percent = v["thr"]
+                eng = Engine(ui_push_snapshot=lambda _: None, ui_log=self.log, name=f"TEST-{v['id']}")
+                eng.cfg = cfg_copy
+                eng.mode = "SIM"
+                eng.llm = self.llm
+                eng.start()
+                start = time.time()
+                while not self._stop.is_set() and len(eng._closed_orders) < self.min_orders:
+                    time.sleep(1)
+                    if time.time() - start > 300:
+                        break
+                v["pnl"] = eng.state.pnl_intraday_percent
+                eng.stop()
+                try:
+                    eng.join(timeout=5)
+                except Exception:
+                    pass
 
             summary = "\n".join(
                 [f"Bot {v['id']}: thr={v['thr']:.4f}, pnl={v['pnl']:.2f}" for v in variants]

--- a/ui_app.py
+++ b/ui_app.py
@@ -105,6 +105,8 @@ class App(tb.Window):
         self._engine_live: Engine | None = None
         self.exchange = None
         self._tester: TestManager | None = None
+        self.var_min_orders = tb.IntVar(value=50)
+        self._auto_started_sim = False
 
         self.metric_defaults = dict(self.cfg.weights)
         self.metric_vars: Dict[str, tb.BooleanVar] = {}
@@ -321,9 +323,12 @@ class App(tb.Window):
         frm_info.rowconfigure(0, weight=1); frm_info.columnconfigure(0, weight=1); frm_info.columnconfigure(1, weight=1)
         self.txt_info = ScrolledText(frm_info, height=6, autohide=True, wrap="word")
         self.txt_info.grid(row=0, column=0, columnspan=2, sticky="nsew")
-        ttk.Button(frm_info, text="Iniciar Testeos", command=self._start_tests).grid(row=1, column=0, columnspan=2, sticky="ew", pady=(4,0))
-        ttk.Button(frm_info, text="Revertir patch", command=self._revert_patch).grid(row=2, column=0, sticky="ew", pady=(4,0))
-        ttk.Button(frm_info, text="Aplicar a LIVE", command=self._apply_winner_live).grid(row=2, column=1, sticky="ew", pady=(4,0))
+        ttk.Label(frm_info, text="Órdenes mínimas").grid(row=1, column=0, sticky="w")
+        ttk.Entry(frm_info, textvariable=self.var_min_orders, width=10).grid(row=1, column=1, sticky="e")
+        self.btn_tests = ttk.Button(frm_info, text="Iniciar Testeos", command=self._toggle_tests)
+        self.btn_tests.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(4,0))
+        ttk.Button(frm_info, text="Revertir patch", command=self._revert_patch).grid(row=3, column=0, sticky="ew", pady=(4,0))
+        ttk.Button(frm_info, text="Aplicar a LIVE", command=self._apply_winner_live).grid(row=3, column=1, sticky="ew", pady=(4,0))
 
         # Métricas de Score
         frm_met = ttk.Labelframe(right, text="Métricas Score", padding=8)
@@ -606,6 +611,9 @@ class App(tb.Window):
     def _apply_binance_keys(self):
         key = self.var_bin_key.get().strip()
         sec = self.var_bin_sec.get().strip()
+        if not key or not sec:
+            self.log_append("[ENGINE] Claves de Binance incompletas.")
+            return False
         self._ensure_exchange()
         self.exchange.set_api_keys(key, sec)
         if self._engine_sim:
@@ -615,9 +623,9 @@ class App(tb.Window):
         self.log_append("[ENGINE] Claves de Binance aplicadas.")
         try:
             self.exchange.load_markets()
-            return True
-        except Exception:
-            return False
+        except Exception as e:
+            self.log_append(f"[ENGINE] No se pudieron verificar las claves ({e}). Continuando de todos modos.")
+        return True
 
     def _apply_openai_key(self):
         k = self.var_oai_key.get().strip()
@@ -674,10 +682,31 @@ class App(tb.Window):
             self._engine_live.cfg.weights = dict(self.cfg.weights)
         threading.Thread(target=self._refresh_market_candidates, daemon=True).start()
 
-    def _start_tests(self):
-        if not self._engine_sim:
-            self.log_append("[TEST] Motor SIM no iniciado")
+    def _toggle_tests(self):
+        if self._tester and self._tester.is_alive():
+            self._tester.stop()
+            try:
+                self._tester.join(timeout=2)
+            except Exception:
+                pass
+            self._tester = None
+            self.btn_tests.configure(text="Iniciar Testeos")
+            self.log_append("[TEST] Ciclo de testeo detenido")
+            if self._auto_started_sim and self._engine_sim:
+                self._engine_sim.stop()
+                self._engine_sim = None
+                self.var_bot_sim.set(False)
+                self.lbl_state_sim.configure(text="SIM: OFF", bootstyle=SECONDARY)
+                self.log_append("[ENGINE SIM] Bot SIM detenido.")
             return
+        if not self._engine_sim or not self._engine_sim.is_alive():
+            self._auto_started_sim = True
+            self._start_engine_sim()
+            self.var_bot_sim.set(True)
+            self.lbl_state_sim.configure(text="SIM: ON", bootstyle=SUCCESS)
+            self.log_append("[ENGINE SIM] Bot SIM iniciado automáticamente para tests.")
+        else:
+            self._auto_started_sim = False
         if self._tester and self._tester.is_alive():
             self.log_append("[TEST] Ciclo de testeo ya en ejecución")
             return
@@ -687,8 +716,10 @@ class App(tb.Window):
                 self.txt_info.see("end")
             self.after(0, upd)
         self.txt_info.delete("1.0", "end")
-        self._tester = TestManager(self._engine_sim.cfg, self._engine_sim.llm, self.log_append, info)
+        min_orders = max(1, int(self.var_min_orders.get()))
+        self._tester = TestManager(self._engine_sim.cfg, self._engine_sim.llm, self.log_append, info, min_orders=min_orders)
         self._tester.start()
+        self.btn_tests.configure(text="Detener Testeos")
         self.log_append("[TEST] Ciclo de testeo iniciado")
 
     def _apply_winner_live(self):


### PR DESCRIPTION
## Summary
- Permite definir órdenes mínimas antes de evaluar estrategias
- Botón de inicio de testeos ahora arranca/parar ciclo y motor SIM automáticamente
- El gestor de tests ejecuta variaciones reales del motor hasta alcanzar las órdenes mínimas
- Confirmar APIs desbloquea la interfaz incluso si la verificación de Binance falla

## Testing
- `python -m py_compile ui_app.py test_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68a06bcc267883288321ccc0307b2638