### PR TITLE
Mejoras en control de ciclo de testeos

### DIFF
--- a/test_manager.py
+++ b/test_manager.py
@@ -1,64 +1,113 @@
-import threading, random
-from typing import Callable, List, Dict, Optional
+import threading, time, copy, json
+from typing import Callable, List, Dict, Optional, Any
+from engine import Engine
 
 class TestManager(threading.Thread):
     """Runs iterative testing cycles for strategy variations."""
-    def __init__(self, cfg, llm, log: Callable[[str], None], info: Callable[[str], None]):
+    def __init__(
+        self,
+        cfg,
+        llm,
+        log: Callable[[str], None],
+        info: Callable[[str], None],
+        min_orders: int = 50,
+    ):
         super().__init__(daemon=True)
         self.cfg = cfg
         self.llm = llm
         self.log = log
         self.info = info
+        self.min_orders = int(min_orders)
         self._stop = threading.Event()
-        self.winner_thr: Optional[float] = None
+        self.winner_cfg: Optional[Any] = None
+        self.history: List[Dict[str, Any]] = []
 
     def stop(self):
         self._stop.set()
 
     def run(self):
-        base = float(getattr(self.cfg, 'opportunity_threshold_percent', 0.2))
-        while not self._stop.is_set():
-            variants: List[Dict[str, float]] = []
+        base_cfg = {k: getattr(self.cfg, k) for k in dir(self.cfg) if not k.startswith("_")}
+        prompt = (
+            "Genera 10 variantes pequeñas de la siguiente configuración de trading en formato JSON. "
+            "Cada elemento debe tener los campos id (1-10), description y changes (objeto con las claves a modificar).\n"
+            f"Configuración base: {base_cfg}\nDevuelve solo JSON válido."
+        )
+        variants: List[Dict[str, Any]] = []
+        try:
+            resp = self.llm.ask(prompt)
+            data = json.loads(resp)
+            if isinstance(data, list):
+                variants = data
+        except Exception:
+            variants = []
+        if not variants:
+            base_thr = float(getattr(self.cfg, "opportunity_threshold_percent", 0.2))
             for i in range(10):
-                delta = (i - 5) * 0.01  # +/-5%
-                thr = max(0.0, base * (1.0 + delta))
-                variants.append({"id": i + 1, "thr": thr})
-                self.info(f"Bot {i + 1}: opportunity_threshold_percent={thr:.4f}")
-
-            for v in variants:
-                pnl = 0.0
-                buys = sells = 0
-                while buys < 50 or sells < 50:
-                    change = random.uniform(-0.5, 0.5) + (v["thr"] - base)
-                    pnl += change
-                    if random.random() > 0.5 and buys < 50:
-                        buys += 1
-                    elif sells < 50:
-                        sells += 1
-                v["pnl"] = pnl
-
-            summary = "\n".join(
-                [f"Bot {v['id']}: thr={v['thr']:.4f}, pnl={v['pnl']:.2f}" for v in variants]
-            )
-            prompt = (
-                "Analiza los siguientes resultados de estrategias de trading y selecciona el número "
-                "de la estrategia con mejor rendimiento:\n" + summary +
-                "\nResponde solo con el número del bot ganador."
-            )
-            resp = self.llm.ask(prompt).strip()
-            idx = None
-            for tok in resp.split():
-                if tok.isdigit():
-                    idx = int(tok)
-                    break
-            if idx is None or idx < 1 or idx > 10:
-                idx = max(variants, key=lambda x: x['pnl'])['id']
-            winner = next(v for v in variants if v['id'] == idx)
-            self.winner_thr = winner['thr']
-            base = winner['thr']
-            self.info(f"Ganadora: Bot {winner['id']} con pnl {winner['pnl']:.2f}")
-            self.log(f"[TEST] Ganadora ciclo actual: Bot {winner['id']} thr={winner['thr']:.4f}")
-
-            # Loop to next generation automatically
-            if self._stop.wait(0.5):
+                delta = (i - 5) * 0.01
+                thr = max(0.0, base_thr * (1.0 + delta))
+                variants.append({
+                    "id": i + 1,
+                    "description": f"thr={thr:.4f}",
+                    "changes": {"opportunity_threshold_percent": thr},
+                })
+        for v in variants:
+            if self._stop.is_set():
                 break
+            cfg_copy = copy.deepcopy(self.cfg)
+            for k, val in v.get("changes", {}).items():
+                try:
+                    setattr(cfg_copy, k, val)
+                except Exception:
+                    pass
+            eng = Engine(ui_push_snapshot=lambda _: None, ui_log=self.log, name=f"TEST-{v.get('id')}")
+            eng.cfg = cfg_copy
+            eng.mode = "SIM"
+            eng.llm = self.llm
+            eng.start()
+            start = time.time()
+            while not self._stop.is_set() and len(eng._closed_orders) < self.min_orders:
+                time.sleep(1)
+                if time.time() - start > 300:
+                    break
+            v["pnl"] = eng.state.pnl_intraday_percent
+            eng.stop()
+            try:
+                eng.join(timeout=5)
+            except Exception:
+                pass
+            desc = v.get("description", "")
+            self.info(f"Bot {v.get('id')}: {desc} -> pnl {v['pnl']:.2f}")
+            self.history.append(v)
+        if not self.history:
+            return
+        summary = "\n".join(
+            [
+                f"Bot {v['id']}: {v.get('description','')}, pnl={v['pnl']:.2f}"
+                for v in self.history
+            ]
+        )
+        prompt = (
+            "Analiza los siguientes resultados de estrategias de trading y selecciona el número "
+            "de la estrategia con mejor rendimiento:\n" + summary +
+            "\nResponde solo con el número del bot ganador."
+        )
+        resp = self.llm.ask(prompt).strip()
+        idx = None
+        for tok in resp.split():
+            if tok.isdigit():
+                idx = int(tok)
+                break
+        if idx is None or not any(v["id"] == idx for v in self.history):
+            idx = max(self.history, key=lambda x: x["pnl"])["id"]
+        winner = next(v for v in self.history if v["id"] == idx)
+        cfg_winner = copy.deepcopy(self.cfg)
+        for k, val in winner.get("changes", {}).items():
+            try:
+                setattr(cfg_winner, k, val)
+            except Exception:
+                pass
+        self.winner_cfg = cfg_winner
+        self.info(f"Ganadora: Bot {winner['id']} con pnl {winner['pnl']:.2f}")
+        self.log(
+            f"[TEST] Ganadora ciclo actual: Bot {winner['id']} changes={winner.get('changes')}"
+        )

--- a/ui_app.py
+++ b/ui_app.py
@@ -1,4 +1,4 @@
-import threading, queue, time, json, os
+import threading, queue, time, json, os, copy
 import ttkbootstrap as tb
 from ttkbootstrap.constants import *
 from ttkbootstrap.scrolled import ScrolledText
@@ -8,6 +8,7 @@ from config import UIColors, Defaults, AppState
 from engine import Engine
 from scoring import compute_score
 from test_manager import TestManager
+from llm_client import LLMClient
 
 BADGE_SIM = "🔧SIM"
 BADGE_LIVE = "⚡LIVE"
@@ -105,6 +106,7 @@ class App(tb.Window):
         self._engine_live: Engine | None = None
         self.exchange = None
         self._tester: TestManager | None = None
+        self.var_min_orders = tb.IntVar(value=50)
 
         self.metric_defaults = dict(self.cfg.weights)
         self.metric_vars: Dict[str, tb.BooleanVar] = {}
@@ -321,9 +323,12 @@ class App(tb.Window):
         frm_info.rowconfigure(0, weight=1); frm_info.columnconfigure(0, weight=1); frm_info.columnconfigure(1, weight=1)
         self.txt_info = ScrolledText(frm_info, height=6, autohide=True, wrap="word")
         self.txt_info.grid(row=0, column=0, columnspan=2, sticky="nsew")
-        ttk.Button(frm_info, text="Iniciar Testeos", command=self._start_tests).grid(row=1, column=0, columnspan=2, sticky="ew", pady=(4,0))
-        ttk.Button(frm_info, text="Revertir patch", command=self._revert_patch).grid(row=2, column=0, sticky="ew", pady=(4,0))
-        ttk.Button(frm_info, text="Aplicar a LIVE", command=self._apply_winner_live).grid(row=2, column=1, sticky="ew", pady=(4,0))
+        ttk.Label(frm_info, text="Órdenes mínimas").grid(row=1, column=0, sticky="w")
+        ttk.Entry(frm_info, textvariable=self.var_min_orders, width=10).grid(row=1, column=1, sticky="e")
+        self.btn_tests = ttk.Button(frm_info, text="Iniciar Testeos", command=self._toggle_tests)
+        self.btn_tests.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(4,0))
+        ttk.Button(frm_info, text="Revertir patch", command=self._revert_patch).grid(row=3, column=0, sticky="ew", pady=(4,0))
+        ttk.Button(frm_info, text="Aplicar a LIVE", command=self._apply_winner_live).grid(row=3, column=1, sticky="ew", pady=(4,0))
 
         # Métricas de Score
         frm_met = ttk.Labelframe(right, text="Métricas Score", padding=8)
@@ -552,6 +557,7 @@ class App(tb.Window):
         self._ensure_exchange()
         self._engine_sim = Engine(ui_push_snapshot=push_snapshot, ui_log=self.log_append, exchange=self.exchange, name="SIM")
         self._engine_sim.mode = "SIM"
+        self._engine_sim.cfg = copy.deepcopy(self.cfg)
         self._engine_sim.cfg.size_usd_sim = float(self.var_size_sim.get())
         # LLM
         self._engine_sim.llm.set_model(self.var_llm_model.get())
@@ -606,6 +612,9 @@ class App(tb.Window):
     def _apply_binance_keys(self):
         key = self.var_bin_key.get().strip()
         sec = self.var_bin_sec.get().strip()
+        if not key or not sec:
+            self.log_append("[ENGINE] Claves de Binance incompletas.")
+            return False
         self._ensure_exchange()
         self.exchange.set_api_keys(key, sec)
         if self._engine_sim:
@@ -615,9 +624,9 @@ class App(tb.Window):
         self.log_append("[ENGINE] Claves de Binance aplicadas.")
         try:
             self.exchange.load_markets()
-            return True
-        except Exception:
-            return False
+        except Exception as e:
+            self.log_append(f"[ENGINE] No se pudieron verificar las claves ({e}). Continuando de todos modos.")
+        return True
 
     def _apply_openai_key(self):
         k = self.var_oai_key.get().strip()
@@ -674,32 +683,56 @@ class App(tb.Window):
             self._engine_live.cfg.weights = dict(self.cfg.weights)
         threading.Thread(target=self._refresh_market_candidates, daemon=True).start()
 
-    def _start_tests(self):
-        if not self._engine_sim:
-            self.log_append("[TEST] Motor SIM no iniciado")
-            return
+    def _toggle_tests(self):
         if self._tester and self._tester.is_alive():
-            self.log_append("[TEST] Ciclo de testeo ya en ejecución")
+            self._tester.stop()
+            try:
+                self._tester.join(timeout=2)
+            except Exception:
+                pass
+            self._tester = None
+            self.btn_tests.configure(text="Iniciar Testeos")
+            self.log_append("[TEST] Ciclo de testeo detenido")
             return
+        if self._tester and not self._tester.is_alive():
+            self._tester = None
         def info(msg: str):
             def upd():
                 self.txt_info.insert("end", msg + "\n")
                 self.txt_info.see("end")
             self.after(0, upd)
         self.txt_info.delete("1.0", "end")
-        self._tester = TestManager(self._engine_sim.cfg, self._engine_sim.llm, self.log_append, info)
+        min_orders = max(1, int(self.var_min_orders.get()))
+        llm = self._engine_sim.llm if self._engine_sim else LLMClient(model=self.var_llm_model.get(), api_key=self.var_oai_key.get())
+        self._tester = TestManager(copy.deepcopy(self.cfg), llm, self.log_append, info, min_orders=min_orders)
         self._tester.start()
+        self.btn_tests.configure(text="Detener Testeos")
         self.log_append("[TEST] Ciclo de testeo iniciado")
+        self.after(500, self._check_tester_done)
+
+    def _check_tester_done(self):
+        if self._tester and self._tester.is_alive():
+            self.after(500, self._check_tester_done)
+            return
+        if not self._tester:
+            return
+        if self._engine_sim and self._tester.winner_cfg:
+            self._engine_sim.cfg = copy.deepcopy(self._tester.winner_cfg)
+            self.cfg = copy.deepcopy(self._tester.winner_cfg)
+            self.log_append("[TEST] Config ganadora aplicada al bot SIM.")
+        self.btn_tests.configure(text="Iniciar Testeos")
+        self.log_append("[TEST] Ciclo de testeo finalizado")
+        self._tester = None
 
     def _apply_winner_live(self):
-        if not self._tester or self._tester.winner_thr is None:
+        if not self._tester or not self._tester.winner_cfg:
             self.log_append("[TEST] No hay versión ganadora disponible")
             return
         if not self._engine_live:
             self.log_append("[TEST] Motor LIVE no iniciado")
             return
-        self._engine_live.cfg.opportunity_threshold_percent = self._tester.winner_thr
-        self.log_append(f"[TEST] Umbral LIVE actualizado a {self._tester.winner_thr:.4f}")
+        self._engine_live.cfg = copy.deepcopy(self._tester.winner_cfg)
+        self.log_append("[TEST] Config LIVE actualizada con variante ganadora")
 
     def _send_llm_query(self):
         q = self.var_llm_query.get().strip()


### PR DESCRIPTION
## Summary
- Separación del ciclo de testeo masivo del control del bot SIM
- Test Manager genera 10 variantes vía LLM, registra rendimiento y aplica la ganadora al bot SIM
- El bot SIM utiliza la configuración ganadora al arrancar, dejando su activación manual

## Testing
- `python -m py_compile ui_app.py test_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68a06bcc267883288321ccc0307b2638