### PR TITLE
Mejoras en control de ciclo de testeos

### DIFF
--- a/test_manager.py
+++ b/test_manager.py
@@ -1,64 +1,113 @@
-import threading, random
-from typing import Callable, List, Dict, Optional
+import threading, time, copy, json
+from typing import Callable, List, Dict, Optional, Any
+from engine import Engine
 
 class TestManager(threading.Thread):
     """Runs iterative testing cycles for strategy variations."""
-    def __init__(self, cfg, llm, log: Callable[[str], None], info: Callable[[str], None]):
+    def __init__(
+        self,
+        cfg,
+        llm,
+        log: Callable[[str], None],
+        info: Callable[[str], None],
+        min_orders: int = 50,
+    ):
         super().__init__(daemon=True)
         self.cfg = cfg
         self.llm = llm
         self.log = log
         self.info = info
+        self.min_orders = int(min_orders)
         self._stop = threading.Event()
-        self.winner_thr: Optional[float] = None
+        self.winner_cfg: Optional[Any] = None
+        self.history: List[Dict[str, Any]] = []
 
     def stop(self):
         self._stop.set()
 
     def run(self):
-        base = float(getattr(self.cfg, 'opportunity_threshold_percent', 0.2))
-        while not self._stop.is_set():
-            variants: List[Dict[str, float]] = []
+        base_cfg = {k: getattr(self.cfg, k) for k in dir(self.cfg) if not k.startswith("_")}
+        prompt = (
+            "Genera 10 variantes pequeñas de la siguiente configuración de trading en formato JSON. "
+            "Cada elemento debe tener los campos id (1-10), description y changes (objeto con las claves a modificar).\n"
+            f"Configuración base: {base_cfg}\nDevuelve solo JSON válido."
+        )
+        variants: List[Dict[str, Any]] = []
+        try:
+            resp = self.llm.ask(prompt)
+            data = json.loads(resp)
+            if isinstance(data, list):
+                variants = data
+        except Exception:
+            variants = []
+        if not variants:
+            base_thr = float(getattr(self.cfg, "opportunity_threshold_percent", 0.2))
             for i in range(10):
-                delta = (i - 5) * 0.01  # +/-5%
-                thr = max(0.0, base * (1.0 + delta))
-                variants.append({"id": i + 1, "thr": thr})
-                self.info(f"Bot {i + 1}: opportunity_threshold_percent={thr:.4f}")
-
-            for v in variants:
-                pnl = 0.0
-                buys = sells = 0
-                while buys < 50 or sells < 50:
-                    change = random.uniform(-0.5, 0.5) + (v["thr"] - base)
-                    pnl += change
-                    if random.random() > 0.5 and buys < 50:
-                        buys += 1
-                    elif sells < 50:
-                        sells += 1
-                v["pnl"] = pnl
-
-            summary = "\n".join(
-                [f"Bot {v['id']}: thr={v['thr']:.4f}, pnl={v['pnl']:.2f}" for v in variants]
-            )
-            prompt = (
-                "Analiza los siguientes resultados de estrategias de trading y selecciona el número "
-                "de la estrategia con mejor rendimiento:\n" + summary +
-                "\nResponde solo con el número del bot ganador."
-            )
-            resp = self.llm.ask(prompt).strip()
-            idx = None
-            for tok in resp.split():
-                if tok.isdigit():
-                    idx = int(tok)
-                    break
-            if idx is None or idx < 1 or idx > 10:
-                idx = max(variants, key=lambda x: x['pnl'])['id']
-            winner = next(v for v in variants if v['id'] == idx)
-            self.winner_thr = winner['thr']
-            base = winner['thr']
-            self.info(f"Ganadora: Bot {winner['id']} con pnl {winner['pnl']:.2f}")
-            self.log(f"[TEST] Ganadora ciclo actual: Bot {winner['id']} thr={winner['thr']:.4f}")
-
-            # Loop to next generation automatically
-            if self._stop.wait(0.5):
+                delta = (i - 5) * 0.01
+                thr = max(0.0, base_thr * (1.0 + delta))
+                variants.append({
+                    "id": i + 1,
+                    "description": f"thr={thr:.4f}",
+                    "changes": {"opportunity_threshold_percent": thr},
+                })
+        for v in variants:
+            if self._stop.is_set():
                 break
+            cfg_copy = copy.deepcopy(self.cfg)
+            for k, val in v.get("changes", {}).items():
+                try:
+                    setattr(cfg_copy, k, val)
+                except Exception:
+                    pass
+            eng = Engine(ui_push_snapshot=lambda _: None, ui_log=self.log, name=f"TEST-{v.get('id')}")
+            eng.cfg = cfg_copy
+            eng.mode = "SIM"
+            eng.llm = self.llm
+            eng.start()
+            start = time.time()
+            while not self._stop.is_set() and len(eng._closed_orders) < self.min_orders:
+                time.sleep(1)
+                if time.time() - start > 300:
+                    break
+            v["pnl"] = eng.state.pnl_intraday_percent
+            eng.stop()
+            try:
+                eng.join(timeout=5)
+            except Exception:
+                pass
+            desc = v.get("description", "")
+            self.info(f"Bot {v.get('id')}: {desc} -> pnl {v['pnl']:.2f}")
+            self.history.append(v)
+        if not self.history:
+            return
+        summary = "\n".join(
+            [
+                f"Bot {v['id']}: {v.get('description','')}, pnl={v['pnl']:.2f}"
+                for v in self.history
+            ]
+        )
+        prompt = (
+            "Analiza los siguientes resultados de estrategias de trading y selecciona el número "
+            "de la estrategia con mejor rendimiento:\n" + summary +
+            "\nResponde solo con el número del bot ganador."
+        )
+        resp = self.llm.ask(prompt).strip()
+        idx = None
+        for tok in resp.split():
+            if tok.isdigit():
+                idx = int(tok)
+                break
+        if idx is None or not any(v["id"] == idx for v in self.history):
+            idx = max(self.history, key=lambda x: x["pnl"])["id"]
+        winner = next(v for v in self.history if v["id"] == idx)
+        cfg_winner = copy.deepcopy(self.cfg)
+        for k, val in winner.get("changes", {}).items():
+            try:
+                setattr(cfg_winner, k, val)
+            except Exception:
+                pass
+        self.winner_cfg = cfg_winner
+        self.info(f"Ganadora: Bot {winner['id']} con pnl {winner['pnl']:.2f}")
+        self.log(
+            f"[TEST] Ganadora ciclo actual: Bot {winner['id']} changes={winner.get('changes')}"
+        )


### PR DESCRIPTION
## Summary
- Se detiene el motor y los bots si Binance devuelve un mensaje de IP ban o exceso de peso
- Se reduce el número de peticiones con caché de métricas y refrescos limitados
- Se limita el universo a escanear en cada snapshot para aliviar la carga

## Testing
- `python -m py_compile engine.py exchange_utils.py ui_app.py test_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68a06bcc267883288321ccc0307b2638