### PR TITLE
Fix NameError in BinanceWS snapshot

### DIFF
--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -119,7 +119,6 @@ class BinanceWS:
                     "bid_top_qty": top_bid_qty, "ask_top_qty": top_ask_qty,
                     "trade_flow": {"buy_ratio": buy_ratio, "streak": int(flow.get("streak",0))},
                 }
-        self._top_metrics_cache = {"ts": now, "symbols": symbols, "data": list(out)}
         return out
 
     def latency_ms(self) -> float:


### PR DESCRIPTION
## Summary
- Remove stale cache assignment referencing undefined `now` in `BinanceWS.snapshot_for`
- Prevent market refresh failures from NameError

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0798f2624832893a3143ae49091c6