### PR TITLE
feat: add bot runner and base strategy

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,41 @@
+"""Trading engine package exposing strategy utilities and helpers."""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from .legacy import Engine
+from .strategy_base import StrategyBase
+from .strategy_params import map_mutations
+
+
+def create_engine(
+    exchange: Optional[Any] = None,
+    config_overrides: Optional[Dict[str, Any]] = None,
+    mutations: Optional[Dict[str, Any]] = None,
+    on_order: Optional[Callable[[Dict[str, Any]], None]] = None,
+) -> Engine:
+    """Instantiate :class:`Engine` applying overrides and hooks.
+
+    Parameters
+    ----------
+    exchange: object, optional
+        Exchange implementation to use. If ``None`` a default Binance
+        exchange is created by :class:`Engine`.
+    config_overrides: dict, optional
+        Values to override in the engine configuration.
+    mutations: dict, optional
+        Strategy mutations to store in the engine instance for external
+        introspection.
+    on_order: callable, optional
+        Callback invoked when the engine places or fills an order.
+    """
+    engine = Engine(ui_push_snapshot=lambda _: None, exchange=exchange)
+    if config_overrides:
+        for key, value in config_overrides.items():
+            setattr(engine.cfg, key, value)
+    engine.mutations = mutations or {}
+    if on_order:
+        engine.set_order_hook(on_order)
+    return engine
+
+__all__ = ["Engine", "StrategyBase", "map_mutations", "create_engine"]

--- a/engine/strategy_base.py
+++ b/engine/strategy_base.py
@@ -1,0 +1,54 @@
+"""Base trading strategy executing the original BTC method.
+
+The strategy is purposely simple and parameter driven so that mutation
+values can tweak its behaviour. All operations are expected to run on an
+exchange object exposing ``get_order_book`` and order creation methods.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+class StrategyBase:
+    """Implements the minimal trading operations used by bots."""
+
+    def __init__(self, exchange: Any) -> None:
+        self.exchange = exchange
+
+    async def select_pairs(self, params: Dict[str, Any]) -> List[str]:
+        """Select tradeable symbols based on the original BTC method."""
+        universe: Iterable[str] = params.get("universe", [])
+        return [sym for sym in universe if sym.endswith("/BTC")]
+
+    async def place_buy(self, params: Dict[str, Any], symbol: str) -> Dict[str, Any]:
+        """Place a buy order one tick above the best bid."""
+        book = await self.exchange.get_order_book(symbol)
+        price = book["best_bid"] + params.get("tick_size", 0.0)
+        amount = params.get("trade_size", 0.0)
+        return await self.exchange.create_limit_buy_order(symbol, amount, price)
+
+    async def place_sell_plus_ticks(
+        self, params: Dict[str, Any], symbol: str, buy_order: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Place a sell order a number of ticks above the buy price."""
+        tick = params.get("tick_size", 0.0)
+        price = buy_order["price"] + tick * params.get("sell_ticks", 1)
+        amount = buy_order["amount"]
+        return await self.exchange.create_limit_sell_order(symbol, amount, price)
+
+    async def monitor_and_adjust(
+        self,
+        params: Dict[str, Any],
+        orders: List[Tuple[Dict[str, Any], Dict[str, Any]]],
+        order_book_provider: Any,
+    ) -> List[Dict[str, Any]]:
+        """Monitor orders until they are filled and compute PNL."""
+        updates: List[Dict[str, Any]] = []
+        for buy, sell in orders:
+            # In mock mode orders are filled instantly. A real implementation
+            # would poll ``order_book_provider`` and adjust orders here.
+            await asyncio.sleep(0)
+            pnl = (sell["price"] - buy["price"]) * buy["amount"]
+            updates.append({"symbol": buy["symbol"], "pnl": pnl})
+        return updates

--- a/engine/strategy_params.py
+++ b/engine/strategy_params.py
@@ -1,0 +1,28 @@
+"""Mapping between mutation dictionaries and concrete strategy parameters."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+DEFAULT_PARAMS: Dict[str, Any] = {
+    "trade_size": 1.0,
+    "tick_size": 0.1,
+    "sell_ticks": 1,
+    "universe": ["ETH/BTC", "LTC/BTC", "XRP/BTC"],
+}
+
+
+def map_mutations(mutations: Dict[str, Any] | None) -> Dict[str, Any]:
+    """Translate raw mutation values into concrete strategy parameters.
+
+    Parameters
+    ----------
+    mutations: dict or None
+        Mutation values produced by the LLM. Unknown keys are ignored.
+    """
+    params = DEFAULT_PARAMS.copy()
+    if not mutations:
+        return params
+    for key, value in mutations.items():
+        if key in params:
+            params[key] = value
+    return params

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,14 @@
+"""Helper exports for orchestrator package."""
+from .models import BotConfig, BotStats, SupervisorEvent
+from .runner import BotRunner
+from .storage import InMemoryStorage
+from .supervisor import Supervisor
+
+__all__ = [
+    "BotRunner",
+    "Supervisor",
+    "BotConfig",
+    "BotStats",
+    "SupervisorEvent",
+    "InMemoryStorage",
+]

--- a/orchestrator/runner.py
+++ b/orchestrator/runner.py
@@ -1,0 +1,80 @@
+"""Asynchronous runner executing a single bot instance."""
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from .models import BotConfig, BotStats
+from engine.strategy_base import StrategyBase
+from engine.strategy_params import map_mutations
+
+
+class BotRunner:
+    """Run a trading bot applying parameter mutations."""
+
+    def __init__(
+        self,
+        config: BotConfig,
+        limits: Dict[str, int],
+        exchange: Any,
+        strategy: StrategyBase,
+        storage: Any,
+        ui_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> None:
+        self.config = config
+        self.limits = limits
+        self.exchange = exchange
+        self.strategy = strategy
+        self.storage = storage
+        self.ui_callback = ui_callback or (lambda _: None)
+
+    async def run(self) -> BotStats:
+        """Execute the bot respecting the provided limits."""
+        params = map_mutations(self.config.mutations)
+        start = time.time()
+        orders_count = 0
+        wins = 0
+        losses = 0
+        pnl = 0.0
+
+        symbols = await self.strategy.select_pairs(params)
+        scans = 1
+        if self.limits.get("max_scans") is not None and scans > self.limits["max_scans"]:
+            raise RuntimeError("scan limit exceeded")
+
+        open_orders: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+        for sym in symbols:
+            if orders_count + 2 > self.limits.get("max_orders", float("inf")):
+                break
+            buy = await self.strategy.place_buy(params, sym)
+            sell = await self.strategy.place_sell_plus_ticks(params, sym, buy)
+            open_orders.append((buy, sell))
+            orders_count += 2
+
+        updates = await self.strategy.monitor_and_adjust(
+            params, open_orders, self.exchange.get_order_book
+        )
+        for upd in updates:
+            pnl += upd.get("pnl", 0.0)
+            if upd.get("pnl", 0.0) >= 0:
+                wins += 1
+            else:
+                losses += 1
+            self.ui_callback({"bot_id": self.config.id, **upd})
+
+        runtime_s = int(time.time() - start)
+        notional = params.get("trade_size", 0.0) * (orders_count / 2)
+        pnl_pct = (pnl / notional * 100.0) if notional else 0.0
+
+        stats = BotStats(
+            bot_id=self.config.id,
+            cycle=self.config.cycle,
+            orders=orders_count,
+            pnl=pnl,
+            pnl_pct=pnl_pct,
+            runtime_s=runtime_s,
+            wins=wins,
+            losses=losses,
+        )
+        self.storage.save_bot_stats(stats)
+        return stats


### PR DESCRIPTION
## Summary
- add BotRunner to execute strategy mutations asynchronously
- introduce parametrizable base strategy and mutation mapping utilities
- expose helper to instantiate engine with hooks; wire order callbacks in legacy engine

## Testing
- `python -m py_compile orchestrator/runner.py engine/__init__.py engine/strategy_base.py engine/strategy_params.py engine/legacy.py orchestrator/__init__.py`
- `python - <<'PY'
import asyncio
from orchestrator import BotRunner, BotConfig, InMemoryStorage
from engine.strategy_base import StrategyBase

class MockExchange:
    def __init__(self):
        self.prices = {
            "ETH/BTC": 0.06,
            "LTC/BTC": 0.003,
            "XRP/BTC": 0.00002,
        }
        self.tick = 0.0001
    async def get_order_book(self, symbol):
        price = self.prices[symbol]
        return {"best_bid": price - self.tick, "best_ask": price + self.tick}
    async def create_limit_buy_order(self, symbol, amount, price):
        return {"id": f"buy-{symbol}", "symbol": symbol, "price": price, "amount": amount, "side": "buy"}
    async def create_limit_sell_order(self, symbol, amount, price):
        return {"id": f"sell-{symbol}", "symbol": symbol, "price": price, "amount": amount, "side": "sell"}

exchange = MockExchange()
storage = InMemoryStorage()

async def run_bot(idx):
    cfg = BotConfig(id=idx, cycle=1, name=f"Bot-{idx}", mutations={}, seed_parent=None)
    strategy = StrategyBase(exchange)
    runner = BotRunner(cfg, {"max_orders": 10, "max_scans": 5, "max_llm_calls": 0}, exchange, strategy, storage, None)
    stats = await runner.run()
    return stats

async def main():
    results = await asyncio.gather(*(run_bot(i) for i in range(10)))
    for r in results:
        print(r)

asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a0ee92e0c4832886b71eefd9285a23