### PR TITLE
feat: add bot runner and base strategy

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,41 @@
+"""Trading engine package exposing strategy utilities and helpers."""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from .legacy import Engine
+from .strategy_base import StrategyBase
+from .strategy_params import map_mutations
+
+
+def create_engine(
+    exchange: Optional[Any] = None,
+    config_overrides: Optional[Dict[str, Any]] = None,
+    mutations: Optional[Dict[str, Any]] = None,
+    on_order: Optional[Callable[[Dict[str, Any]], None]] = None,
+) -> Engine:
+    """Instantiate :class:`Engine` applying overrides and hooks.
+
+    Parameters
+    ----------
+    exchange: object, optional
+        Exchange implementation to use. If ``None`` a default Binance
+        exchange is created by :class:`Engine`.
+    config_overrides: dict, optional
+        Values to override in the engine configuration.
+    mutations: dict, optional
+        Strategy mutations to store in the engine instance for external
+        introspection.
+    on_order: callable, optional
+        Callback invoked when the engine places or fills an order.
+    """
+    engine = Engine(ui_push_snapshot=lambda _: None, exchange=exchange)
+    if config_overrides:
+        for key, value in config_overrides.items():
+            setattr(engine.cfg, key, value)
+    engine.mutations = mutations or {}
+    if on_order:
+        engine.set_order_hook(on_order)
+    return engine
+
+__all__ = ["Engine", "StrategyBase", "map_mutations", "create_engine"]

--- a/engine/strategy_base.py
+++ b/engine/strategy_base.py
@@ -1,0 +1,54 @@
+"""Base trading strategy executing the original BTC method.
+
+The strategy is purposely simple and parameter driven so that mutation
+values can tweak its behaviour. All operations are expected to run on an
+exchange object exposing ``get_order_book`` and order creation methods.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+class StrategyBase:
+    """Implements the minimal trading operations used by bots."""
+
+    def __init__(self, exchange: Any) -> None:
+        self.exchange = exchange
+
+    async def select_pairs(self, params: Dict[str, Any]) -> List[str]:
+        """Select tradeable symbols based on the original BTC method."""
+        universe: Iterable[str] = params.get("universe", [])
+        return [sym for sym in universe if sym.endswith("/BTC")]
+
+    async def place_buy(self, params: Dict[str, Any], symbol: str) -> Dict[str, Any]:
+        """Place a buy order one tick above the best bid."""
+        book = await self.exchange.get_order_book(symbol)
+        price = book["best_bid"] + params.get("tick_size", 0.0)
+        amount = params.get("trade_size", 0.0)
+        return await self.exchange.create_limit_buy_order(symbol, amount, price)
+
+    async def place_sell_plus_ticks(
+        self, params: Dict[str, Any], symbol: str, buy_order: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Place a sell order a number of ticks above the buy price."""
+        tick = params.get("tick_size", 0.0)
+        price = buy_order["price"] + tick * params.get("sell_ticks", 1)
+        amount = buy_order["amount"]
+        return await self.exchange.create_limit_sell_order(symbol, amount, price)
+
+    async def monitor_and_adjust(
+        self,
+        params: Dict[str, Any],
+        orders: List[Tuple[Dict[str, Any], Dict[str, Any]]],
+        order_book_provider: Any,
+    ) -> List[Dict[str, Any]]:
+        """Monitor orders until they are filled and compute PNL."""
+        updates: List[Dict[str, Any]] = []
+        for buy, sell in orders:
+            # In mock mode orders are filled instantly. A real implementation
+            # would poll ``order_book_provider`` and adjust orders here.
+            await asyncio.sleep(0)
+            pnl = (sell["price"] - buy["price"]) * buy["amount"]
+            updates.append({"symbol": buy["symbol"], "pnl": pnl})
+        return updates

--- a/engine/strategy_params.py
+++ b/engine/strategy_params.py
@@ -1,0 +1,28 @@
+"""Mapping between mutation dictionaries and concrete strategy parameters."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+DEFAULT_PARAMS: Dict[str, Any] = {
+    "trade_size": 1.0,
+    "tick_size": 0.1,
+    "sell_ticks": 1,
+    "universe": ["ETH/BTC", "LTC/BTC", "XRP/BTC"],
+}
+
+
+def map_mutations(mutations: Dict[str, Any] | None) -> Dict[str, Any]:
+    """Translate raw mutation values into concrete strategy parameters.
+
+    Parameters
+    ----------
+    mutations: dict or None
+        Mutation values produced by the LLM. Unknown keys are ignored.
+    """
+    params = DEFAULT_PARAMS.copy()
+    if not mutations:
+        return params
+    for key, value in mutations.items():
+        if key in params:
+            params[key] = value
+    return params

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,0 +1,4 @@
+"""LLM helpers package."""
+from .client import LLMClient
+
+__all__ = ["LLMClient"]

--- a/llm/client.py
+++ b/llm/client.py
@@ -1,0 +1,114 @@
+"""Cliente LLM para generar variaciones de estrategia."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List, Optional
+
+from .prompts import PROMPT_INICIAL_VARIACIONES
+
+
+class LLMClient:
+    """Wrapper liviano sobre OpenAI que genera variaciones iniciales.
+
+    Si no hay clave de API o falla la llamada, devuelve un conjunto
+    determinista de 10 variaciones válidas.
+    """
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "gpt-4o-mini") -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY", "")
+        self.model = model
+        self._client = None
+        if self.api_key:
+            try:  # Lazy import para no requerir dependencia siempre
+                from openai import OpenAI  # type: ignore
+
+                self._client = OpenAI(api_key=self.api_key)
+            except Exception:
+                self._client = None
+
+    # ------------------------------------------------------------------
+    def _call_openai(self, trading_spec_text: str) -> List[Dict[str, object]]:
+        assert self._client is not None
+        resp = self._client.chat.completions.create(
+            model=self.model,
+            temperature=0.2,
+            messages=[
+                {"role": "system", "content": PROMPT_INICIAL_VARIACIONES},
+                {"role": "user", "content": trading_spec_text},
+            ],
+            timeout=40,
+        )
+        txt = resp.choices[0].message.content or "[]"
+        data = json.loads(txt)
+        if not isinstance(data, list):
+            raise ValueError("respuesta no es lista")
+        return data
+
+    # ------------------------------------------------------------------
+    def _fallback_variations(self) -> List[Dict[str, object]]:
+        """Genera 10 variaciones deterministas para modo sin LLM."""
+        variations: List[Dict[str, object]] = []
+        for i in range(10):
+            variations.append(
+                {
+                    "name": f"var-{i+1:02d}",
+                    "mutations": {
+                        "order_size_usd": "auto",
+                        "buy_level_rule": "accum_bids",
+                        "sell_rule": "+1_tick",
+                        "imbalance_buy_threshold_pct": 15 + i,
+                        "cancel_replace_rules": {
+                            "enable": True,
+                            "max_moves": i % 5,
+                            "min_depth_ratio": 0.5 + (i % 3) * 0.1,
+                        },
+                        "pair_ranking_window_s": 10 + i,
+                        "min_vol_btc_24h": 5 + i,
+                        "commission_buffer_ticks": 1,
+                        "risk_limits": {
+                            "max_open_orders": 1 + (i % 5),
+                            "per_pair_exposure_usd": 50 + i * 10,
+                        },
+                    },
+                }
+            )
+        return variations
+
+    # ------------------------------------------------------------------
+    def generate_initial_variations(self, trading_spec_text: str) -> List[Dict[str, object]]:
+        """Obtiene 10 variaciones únicas de la estrategia base."""
+        raw: List[Dict[str, object]] = []
+        if self._client is not None:
+            try:
+                raw = self._call_openai(trading_spec_text)
+            except Exception:
+                raw = []
+        if not raw:
+            raw = self._fallback_variations()
+
+        unique: List[Dict[str, object]] = []
+        seen = set()
+        for item in raw:
+            name = str(item.get("name")) if isinstance(item, dict) else ""
+            muts = item.get("mutations") if isinstance(item, dict) else None
+            if not name or not isinstance(muts, dict):
+                continue
+            key = json.dumps(muts, sort_keys=True)
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append({"name": name, "mutations": muts})
+            if len(unique) == 10:
+                break
+
+        # Asegurar 10 variaciones
+        idx = 1
+        while len(unique) < 10:
+            extra_name = f"auto-{idx:02d}"
+            key = json.dumps({"placeholder": idx})
+            if key not in seen:
+                unique.append({"name": extra_name, "mutations": {}})
+                seen.add(key)
+            idx += 1
+        return unique

--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -1,0 +1,30 @@
+"""Prompts estáticos usados por el cliente LLM."""
+
+PROMPT_INICIAL_VARIACIONES = """
+SISTEMA: Eres experto en microestructura y market-making spot en Binance (pares XXXBTC). Tarea: generar 10 variaciones de una estrategia base que compra en nivel con acumulación de bids y vende +1 tick, con filtros: beneficio > comisiones (compra+venta), volumen ≥ 5 BTC/24h y monitoreo del libro para mover/cancelar órdenes ante cambios.
+REQUISITOS:
+- 10 variaciones distintas entre sí (sin duplicados lógicos).
+- Cambia exactamente 1–3 elementos por variación: umbrales de desequilibrio, reglas de entrada/salida, ventana de ranking, límites de exposición, tamaño de orden, cancel/replace, timeout de venta, criterio de venta al precio de compra ante caída del 15%, etc.
+- Mantén el espíritu del método original (venta +1 tick) aunque se permitan “+k_ticks con max_wait_s”.
+FORMATO DE SALIDA:
+Devuelve un JSON array con 10 objetos, cada uno con:
+{
+  "name": "var-<corto-unico>",
+  "mutations": {
+    "order_size_usd": "auto|fijo|%balance",
+    "buy_level_rule": "accum_bids|best_ask_if_imbalance",
+    "sell_rule": "+1_tick|+k_ticks|max_wait_s",
+    "imbalance_buy_threshold_pct": <15-40>,
+    "cancel_replace_rules": {"enable": true, "max_moves": 0-5, "min_depth_ratio": 0.4-0.9},
+    "pair_ranking_window_s": <10-120>,
+    "min_vol_btc_24h": <5-50>,
+    "commission_buffer_ticks": <1-3>,
+    "risk_limits": {"max_open_orders": 1-5, "per_pair_exposure_usd": 10-500}
+  }
+}
+CONSTRICCIONES:
+- Sin dos variaciones con el mismo set efectivo de mutations.
+- Sin ML.
+- Todas aplicables a cualquier XXXBTC independientemente del precio (usar increments del exchange si aplica).
+Valida que el JSON sea parseable.
+"""

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,14 @@
+"""Helper exports for orchestrator package."""
+from .models import BotConfig, BotStats, SupervisorEvent
+from .runner import BotRunner
+from .storage import InMemoryStorage
+from .supervisor import Supervisor
+
+__all__ = [
+    "BotRunner",
+    "Supervisor",
+    "BotConfig",
+    "BotStats",
+    "SupervisorEvent",
+    "InMemoryStorage",
+]

--- a/orchestrator/runner.py
+++ b/orchestrator/runner.py
@@ -1,0 +1,80 @@
+"""Asynchronous runner executing a single bot instance."""
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from .models import BotConfig, BotStats
+from engine.strategy_base import StrategyBase
+from engine.strategy_params import map_mutations
+
+
+class BotRunner:
+    """Run a trading bot applying parameter mutations."""
+
+    def __init__(
+        self,
+        config: BotConfig,
+        limits: Dict[str, int],
+        exchange: Any,
+        strategy: StrategyBase,
+        storage: Any,
+        ui_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> None:
+        self.config = config
+        self.limits = limits
+        self.exchange = exchange
+        self.strategy = strategy
+        self.storage = storage
+        self.ui_callback = ui_callback or (lambda _: None)
+
+    async def run(self) -> BotStats:
+        """Execute the bot respecting the provided limits."""
+        params = map_mutations(self.config.mutations)
+        start = time.time()
+        orders_count = 0
+        wins = 0
+        losses = 0
+        pnl = 0.0
+
+        symbols = await self.strategy.select_pairs(params)
+        scans = 1
+        if self.limits.get("max_scans") is not None and scans > self.limits["max_scans"]:
+            raise RuntimeError("scan limit exceeded")
+
+        open_orders: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+        for sym in symbols:
+            if orders_count + 2 > self.limits.get("max_orders", float("inf")):
+                break
+            buy = await self.strategy.place_buy(params, sym)
+            sell = await self.strategy.place_sell_plus_ticks(params, sym, buy)
+            open_orders.append((buy, sell))
+            orders_count += 2
+
+        updates = await self.strategy.monitor_and_adjust(
+            params, open_orders, self.exchange.get_order_book
+        )
+        for upd in updates:
+            pnl += upd.get("pnl", 0.0)
+            if upd.get("pnl", 0.0) >= 0:
+                wins += 1
+            else:
+                losses += 1
+            self.ui_callback({"bot_id": self.config.id, **upd})
+
+        runtime_s = int(time.time() - start)
+        notional = params.get("trade_size", 0.0) * (orders_count / 2)
+        pnl_pct = (pnl / notional * 100.0) if notional else 0.0
+
+        stats = BotStats(
+            bot_id=self.config.id,
+            cycle=self.config.cycle,
+            orders=orders_count,
+            pnl=pnl,
+            pnl_pct=pnl_pct,
+            runtime_s=runtime_s,
+            wins=wins,
+            losses=losses,
+        )
+        self.storage.save_bot_stats(stats)
+        return stats


### PR DESCRIPTION
## Summary
- add BotRunner to execute strategy mutations asynchronously
- introduce parametrizable base strategy and mutation mapping utilities
- expose helper to instantiate engine with hooks; wire order callbacks in legacy engine
- create LLM client with initial-variation prompt and integrate into supervisor

## Testing
- `python -m py_compile llm/__init__.py llm/prompts.py llm/client.py orchestrator/supervisor.py`
- `python - <<'PY'
import asyncio
from orchestrator import Supervisor
from llm.client import LLMClient

async def main():
    sup = Supervisor()
    def fake_gen(self, spec):
        return [{"name": f"var-{i}", "mutations": {"imbalance_buy_threshold_pct": 20 + i}} for i in range(10)]
    LLMClient.generate_initial_variations = fake_gen
    await sup.run_cycle(1)
    for cfg in sup._current_generation:
        print(cfg.id, cfg.name, cfg.mutations)

asyncio.run(main())
PY`
- `python - <<'PY'
import json
from llm.client import LLMClient
client = LLMClient(api_key="")
vars = client.generate_initial_variations("spec")
print(len(vars))
print(len({json.dumps(v['mutations'], sort_keys=True) for v in vars}))
print(vars[0])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a0ee92e0c4832886b71eefd9285a23