### PR TITLE
feat: add bot runner and base strategy

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,41 @@
+"""Trading engine package exposing strategy utilities and helpers."""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from .legacy import Engine
+from .strategy_base import StrategyBase
+from .strategy_params import map_mutations
+
+
+def create_engine(
+    exchange: Optional[Any] = None,
+    config_overrides: Optional[Dict[str, Any]] = None,
+    mutations: Optional[Dict[str, Any]] = None,
+    on_order: Optional[Callable[[Dict[str, Any]], None]] = None,
+) -> Engine:
+    """Instantiate :class:`Engine` applying overrides and hooks.
+
+    Parameters
+    ----------
+    exchange: object, optional
+        Exchange implementation to use. If ``None`` a default Binance
+        exchange is created by :class:`Engine`.
+    config_overrides: dict, optional
+        Values to override in the engine configuration.
+    mutations: dict, optional
+        Strategy mutations to store in the engine instance for external
+        introspection.
+    on_order: callable, optional
+        Callback invoked when the engine places or fills an order.
+    """
+    engine = Engine(ui_push_snapshot=lambda _: None, exchange=exchange)
+    if config_overrides:
+        for key, value in config_overrides.items():
+            setattr(engine.cfg, key, value)
+    engine.mutations = mutations or {}
+    if on_order:
+        engine.set_order_hook(on_order)
+    return engine
+
+__all__ = ["Engine", "StrategyBase", "map_mutations", "create_engine"]

--- a/engine/strategy_base.py
+++ b/engine/strategy_base.py
@@ -1,0 +1,54 @@
+"""Base trading strategy executing the original BTC method.
+
+The strategy is purposely simple and parameter driven so that mutation
+values can tweak its behaviour. All operations are expected to run on an
+exchange object exposing ``get_order_book`` and order creation methods.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+class StrategyBase:
+    """Implements the minimal trading operations used by bots."""
+
+    def __init__(self, exchange: Any) -> None:
+        self.exchange = exchange
+
+    async def select_pairs(self, params: Dict[str, Any]) -> List[str]:
+        """Select tradeable symbols based on the original BTC method."""
+        universe: Iterable[str] = params.get("universe", [])
+        return [sym for sym in universe if sym.endswith("/BTC")]
+
+    async def place_buy(self, params: Dict[str, Any], symbol: str) -> Dict[str, Any]:
+        """Place a buy order one tick above the best bid."""
+        book = await self.exchange.get_order_book(symbol)
+        price = book["best_bid"] + params.get("tick_size", 0.0)
+        amount = params.get("trade_size", 0.0)
+        return await self.exchange.create_limit_buy_order(symbol, amount, price)
+
+    async def place_sell_plus_ticks(
+        self, params: Dict[str, Any], symbol: str, buy_order: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Place a sell order a number of ticks above the buy price."""
+        tick = params.get("tick_size", 0.0)
+        price = buy_order["price"] + tick * params.get("sell_ticks", 1)
+        amount = buy_order["amount"]
+        return await self.exchange.create_limit_sell_order(symbol, amount, price)
+
+    async def monitor_and_adjust(
+        self,
+        params: Dict[str, Any],
+        orders: List[Tuple[Dict[str, Any], Dict[str, Any]]],
+        order_book_provider: Any,
+    ) -> List[Dict[str, Any]]:
+        """Monitor orders until they are filled and compute PNL."""
+        updates: List[Dict[str, Any]] = []
+        for buy, sell in orders:
+            # In mock mode orders are filled instantly. A real implementation
+            # would poll ``order_book_provider`` and adjust orders here.
+            await asyncio.sleep(0)
+            pnl = (sell["price"] - buy["price"]) * buy["amount"]
+            updates.append({"symbol": buy["symbol"], "pnl": pnl})
+        return updates

--- a/engine/strategy_params.py
+++ b/engine/strategy_params.py
@@ -1,0 +1,28 @@
+"""Mapping between mutation dictionaries and concrete strategy parameters."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+DEFAULT_PARAMS: Dict[str, Any] = {
+    "trade_size": 1.0,
+    "tick_size": 0.1,
+    "sell_ticks": 1,
+    "universe": ["ETH/BTC", "LTC/BTC", "XRP/BTC"],
+}
+
+
+def map_mutations(mutations: Dict[str, Any] | None) -> Dict[str, Any]:
+    """Translate raw mutation values into concrete strategy parameters.
+
+    Parameters
+    ----------
+    mutations: dict or None
+        Mutation values produced by the LLM. Unknown keys are ignored.
+    """
+    params = DEFAULT_PARAMS.copy()
+    if not mutations:
+        return params
+    for key, value in mutations.items():
+        if key in params:
+            params[key] = value
+    return params

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,0 +1,4 @@
+"""LLM helpers package."""
+from .client import LLMClient
+
+__all__ = ["LLMClient"]

--- a/llm/client.py
+++ b/llm/client.py
@@ -1,0 +1,114 @@
+"""Cliente LLM para generar variaciones de estrategia."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List, Optional
+
+from .prompts import PROMPT_INICIAL_VARIACIONES
+
+
+class LLMClient:
+    """Wrapper liviano sobre OpenAI que genera variaciones iniciales.
+
+    Si no hay clave de API o falla la llamada, devuelve un conjunto
+    determinista de 10 variaciones válidas.
+    """
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "gpt-4o-mini") -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY", "")
+        self.model = model
+        self._client = None
+        if self.api_key:
+            try:  # Lazy import para no requerir dependencia siempre
+                from openai import OpenAI  # type: ignore
+
+                self._client = OpenAI(api_key=self.api_key)
+            except Exception:
+                self._client = None
+
+    # ------------------------------------------------------------------
+    def _call_openai(self, trading_spec_text: str) -> List[Dict[str, object]]:
+        assert self._client is not None
+        resp = self._client.chat.completions.create(
+            model=self.model,
+            temperature=0.2,
+            messages=[
+                {"role": "system", "content": PROMPT_INICIAL_VARIACIONES},
+                {"role": "user", "content": trading_spec_text},
+            ],
+            timeout=40,
+        )
+        txt = resp.choices[0].message.content or "[]"
+        data = json.loads(txt)
+        if not isinstance(data, list):
+            raise ValueError("respuesta no es lista")
+        return data
+
+    # ------------------------------------------------------------------
+    def _fallback_variations(self) -> List[Dict[str, object]]:
+        """Genera 10 variaciones deterministas para modo sin LLM."""
+        variations: List[Dict[str, object]] = []
+        for i in range(10):
+            variations.append(
+                {
+                    "name": f"var-{i+1:02d}",
+                    "mutations": {
+                        "order_size_usd": "auto",
+                        "buy_level_rule": "accum_bids",
+                        "sell_rule": "+1_tick",
+                        "imbalance_buy_threshold_pct": 15 + i,
+                        "cancel_replace_rules": {
+                            "enable": True,
+                            "max_moves": i % 5,
+                            "min_depth_ratio": 0.5 + (i % 3) * 0.1,
+                        },
+                        "pair_ranking_window_s": 10 + i,
+                        "min_vol_btc_24h": 5 + i,
+                        "commission_buffer_ticks": 1,
+                        "risk_limits": {
+                            "max_open_orders": 1 + (i % 5),
+                            "per_pair_exposure_usd": 50 + i * 10,
+                        },
+                    },
+                }
+            )
+        return variations
+
+    # ------------------------------------------------------------------
+    def generate_initial_variations(self, trading_spec_text: str) -> List[Dict[str, object]]:
+        """Obtiene 10 variaciones únicas de la estrategia base."""
+        raw: List[Dict[str, object]] = []
+        if self._client is not None:
+            try:
+                raw = self._call_openai(trading_spec_text)
+            except Exception:
+                raw = []
+        if not raw:
+            raw = self._fallback_variations()
+
+        unique: List[Dict[str, object]] = []
+        seen = set()
+        for item in raw:
+            name = str(item.get("name")) if isinstance(item, dict) else ""
+            muts = item.get("mutations") if isinstance(item, dict) else None
+            if not name or not isinstance(muts, dict):
+                continue
+            key = json.dumps(muts, sort_keys=True)
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append({"name": name, "mutations": muts})
+            if len(unique) == 10:
+                break
+
+        # Asegurar 10 variaciones
+        idx = 1
+        while len(unique) < 10:
+            extra_name = f"auto-{idx:02d}"
+            key = json.dumps({"placeholder": idx})
+            if key not in seen:
+                unique.append({"name": extra_name, "mutations": {}})
+                seen.add(key)
+            idx += 1
+        return unique

--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -1,0 +1,30 @@
+"""Prompts estáticos usados por el cliente LLM."""
+
+PROMPT_INICIAL_VARIACIONES = """
+SISTEMA: Eres experto en microestructura y market-making spot en Binance (pares XXXBTC). Tarea: generar 10 variaciones de una estrategia base que compra en nivel con acumulación de bids y vende +1 tick, con filtros: beneficio > comisiones (compra+venta), volumen ≥ 5 BTC/24h y monitoreo del libro para mover/cancelar órdenes ante cambios.
+REQUISITOS:
+- 10 variaciones distintas entre sí (sin duplicados lógicos).
+- Cambia exactamente 1–3 elementos por variación: umbrales de desequilibrio, reglas de entrada/salida, ventana de ranking, límites de exposición, tamaño de orden, cancel/replace, timeout de venta, criterio de venta al precio de compra ante caída del 15%, etc.
+- Mantén el espíritu del método original (venta +1 tick) aunque se permitan “+k_ticks con max_wait_s”.
+FORMATO DE SALIDA:
+Devuelve un JSON array con 10 objetos, cada uno con:
+{
+  "name": "var-<corto-unico>",
+  "mutations": {
+    "order_size_usd": "auto|fijo|%balance",
+    "buy_level_rule": "accum_bids|best_ask_if_imbalance",
+    "sell_rule": "+1_tick|+k_ticks|max_wait_s",
+    "imbalance_buy_threshold_pct": <15-40>,
+    "cancel_replace_rules": {"enable": true, "max_moves": 0-5, "min_depth_ratio": 0.4-0.9},
+    "pair_ranking_window_s": <10-120>,
+    "min_vol_btc_24h": <5-50>,
+    "commission_buffer_ticks": <1-3>,
+    "risk_limits": {"max_open_orders": 1-5, "per_pair_exposure_usd": 10-500}
+  }
+}
+CONSTRICCIONES:
+- Sin dos variaciones con el mismo set efectivo de mutations.
+- Sin ML.
+- Todas aplicables a cualquier XXXBTC independientemente del precio (usar increments del exchange si aplica).
+Valida que el JSON sea parseable.
+"""

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,14 @@
+"""Helper exports for orchestrator package."""
+from .models import BotConfig, BotStats, SupervisorEvent
+from .runner import BotRunner
+from .storage import SQLiteStorage
+from .supervisor import Supervisor
+
+__all__ = [
+    "BotRunner",
+    "Supervisor",
+    "BotConfig",
+    "BotStats",
+    "SupervisorEvent",
+    "SQLiteStorage",
+]

--- a/orchestrator/runner.py
+++ b/orchestrator/runner.py
@@ -1,0 +1,125 @@
+"""Asynchronous runner executing a single bot instance."""
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from .models import BotConfig, BotStats
+from engine.strategy_base import StrategyBase
+from engine.strategy_params import map_mutations
+
+
+class BotRunner:
+    """Run a trading bot applying parameter mutations."""
+
+    def __init__(
+        self,
+        config: BotConfig,
+        limits: Dict[str, int],
+        exchange: Any,
+        strategy: StrategyBase,
+        storage: Any,
+        ui_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> None:
+        self.config = config
+        self.limits = limits
+        self.exchange = exchange
+        self.strategy = strategy
+        self.storage = storage
+        self.ui_callback = ui_callback or (lambda _: None)
+
+    async def run(self) -> BotStats:
+        """Execute the bot respecting the provided limits."""
+        params = map_mutations(self.config.mutations)
+        start = time.time()
+        orders_count = 0
+        wins = 0
+        losses = 0
+        pnl = 0.0
+
+        symbols = await self.strategy.select_pairs(params)
+        scans = 1
+        if self.limits.get("max_scans") is not None and scans > self.limits["max_scans"]:
+            raise RuntimeError("scan limit exceeded")
+
+        open_orders: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+        for sym in symbols:
+            if orders_count + 2 > self.limits.get("max_orders", float("inf")):
+                break
+            buy = await self.strategy.place_buy(params, sym)
+            self.storage.save_order(
+                {
+                    "order_id": buy.get("id"),
+                    "bot_id": self.config.id,
+                    "cycle_id": self.config.cycle,
+                    "symbol": buy.get("symbol", sym),
+                    "side": "buy",
+                    "qty": buy.get("amount"),
+                    "price": buy.get("price"),
+                    "ts": datetime.utcnow().isoformat(),
+                    "status": "open",
+                    "raw_json": json.dumps(buy),
+                }
+            )
+            sell = await self.strategy.place_sell_plus_ticks(params, sym, buy)
+            self.storage.save_order(
+                {
+                    "order_id": sell.get("id"),
+                    "bot_id": self.config.id,
+                    "cycle_id": self.config.cycle,
+                    "symbol": sell.get("symbol", sym),
+                    "side": "sell",
+                    "qty": sell.get("amount"),
+                    "price": sell.get("price"),
+                    "ts": datetime.utcnow().isoformat(),
+                    "status": "open",
+                    "raw_json": json.dumps(sell),
+                }
+            )
+            open_orders.append((buy, sell))
+            orders_count += 2
+
+        updates = await self.strategy.monitor_and_adjust(
+            params, open_orders, self.exchange.get_order_book
+        )
+        for (buy, sell), upd in zip(open_orders, updates):
+            pnl += upd.get("pnl", 0.0)
+            if upd.get("pnl", 0.0) >= 0:
+                wins += 1
+            else:
+                losses += 1
+            for side, order in (("buy", buy), ("sell", sell)):
+                data = {
+                    "order_id": order.get("id"),
+                    "bot_id": self.config.id,
+                    "cycle_id": self.config.cycle,
+                    "symbol": order.get("symbol"),
+                    "side": side,
+                    "qty": order.get("amount"),
+                    "price": order.get("price"),
+                    "ts": datetime.utcnow().isoformat(),
+                    "status": "filled",
+                    "pnl": upd.get("pnl") if side == "sell" else None,
+                    "raw_json": json.dumps(order),
+                }
+                self.storage.save_order(data)
+            self.ui_callback({"bot_id": self.config.id, **upd})
+
+        runtime_s = int(time.time() - start)
+        notional = params.get("trade_size", 0.0) * (orders_count / 2)
+        pnl_pct = (pnl / notional * 100.0) if notional else 0.0
+
+        stats = BotStats(
+            bot_id=self.config.id,
+            cycle=self.config.cycle,
+            orders=orders_count,
+            pnl=pnl,
+            pnl_pct=pnl_pct,
+            runtime_s=runtime_s,
+            wins=wins,
+            losses=losses,
+        )
+        self.storage.save_bot_stats(stats)
+        return stats

--- a/orchestrator/storage.py
+++ b/orchestrator/storage.py
@@ -1,47 +1,277 @@
-"""Almacenamiento en memoria para el orquestador."""
+"""SQLite-backed persistence layer for the orchestrator."""
 from __future__ import annotations
 
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .models import BotConfig, BotStats, SupervisorEvent
 
+DB_FILENAME = "titanbot.db"
 
-class InMemoryStorage:
-    """Persistencia simple utilizando estructuras en memoria."""
 
-    def __init__(self) -> None:
-        self._events: List[SupervisorEvent] = []
-        self._bots: Dict[int, BotConfig] = {}
-        self._bot_stats: Dict[int, BotStats] = {}
-        self._cycle_summary: Dict[int, Dict[str, Any]] = {}
+class SQLiteStorage:
+    """Persist data from supervisors and runners into SQLite."""
 
-    # -- Eventos --
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = db_path or DB_FILENAME
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    def _init_db(self) -> None:
+        """Create tables if they do not yet exist."""
+        schema_path = Path(__file__).resolve().parent.parent / "schema.sql"
+        with open(schema_path, "r", encoding="utf-8") as fh:
+            self.conn.executescript(fh.read())
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    # Events
     def append_event(self, event: SupervisorEvent) -> None:
-        self._events.append(event)
+        with self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO events (ts, level, scope, bot_id, cycle_id, message, payload_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.ts.isoformat(),
+                    event.level,
+                    event.scope,
+                    event.bot_id,
+                    event.cycle,
+                    event.message,
+                    json.dumps(event.payload) if event.payload else None,
+                ),
+            )
 
-    def get_events(self) -> List[SupervisorEvent]:
-        return list(self._events)
+    def get_events(self, cycle: Optional[int] = None) -> List[SupervisorEvent]:
+        query = "SELECT ts, level, scope, bot_id, cycle_id, message, payload_json FROM events"
+        params: List[Any] = []
+        if cycle is not None:
+            query += " WHERE cycle_id = ?"
+            params.append(cycle)
+        rows = self.conn.execute(query, params).fetchall()
+        events = []
+        for row in rows:
+            payload = json.loads(row["payload_json"]) if row["payload_json"] else None
+            events.append(
+                SupervisorEvent(
+                    ts=datetime.fromisoformat(row["ts"]),
+                    level=row["level"],
+                    scope=row["scope"],
+                    cycle=row["cycle_id"],
+                    bot_id=row["bot_id"],
+                    message=row["message"],
+                    payload=payload,
+                )
+            )
+        return events
 
-    # -- Bots --
+    # ------------------------------------------------------------------
+    # Bots
     def save_bot(self, bot_config: BotConfig) -> None:
-        self._bots[bot_config.id] = bot_config
+        with self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO bots (bot_id, cycle_id, name, seed_parent, mutations_json, created_at)
+                VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                ON CONFLICT(bot_id) DO UPDATE SET
+                    cycle_id=excluded.cycle_id,
+                    name=excluded.name,
+                    seed_parent=excluded.seed_parent,
+                    mutations_json=excluded.mutations_json
+                """,
+                (
+                    bot_config.id,
+                    bot_config.cycle,
+                    bot_config.name,
+                    bot_config.seed_parent,
+                    json.dumps(bot_config.mutations),
+                ),
+            )
 
     def get_bot(self, bot_id: int) -> Optional[BotConfig]:
-        return self._bots.get(bot_id)
+        row = self.conn.execute(
+            "SELECT bot_id, cycle_id, name, seed_parent, mutations_json FROM bots WHERE bot_id = ?",
+            (bot_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return BotConfig(
+            id=row["bot_id"],
+            cycle=row["cycle_id"],
+            name=row["name"],
+            mutations=json.loads(row["mutations_json"]) if row["mutations_json"] else {},
+            seed_parent=row["seed_parent"],
+        )
 
-    # -- Stats --
+    # ------------------------------------------------------------------
+    # Bot stats
     def save_bot_stats(self, stats: BotStats) -> None:
-        self._bot_stats[stats.bot_id] = stats
+        with self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO bot_stats (
+                    bot_id, cycle_id, orders, pnl, pnl_pct, runtime_s, wins, losses, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                ON CONFLICT(bot_id, cycle_id) DO UPDATE SET
+                    orders=excluded.orders,
+                    pnl=excluded.pnl,
+                    pnl_pct=excluded.pnl_pct,
+                    runtime_s=excluded.runtime_s,
+                    wins=excluded.wins,
+                    losses=excluded.losses,
+                    updated_at=CURRENT_TIMESTAMP
+                """,
+                (
+                    stats.bot_id,
+                    stats.cycle,
+                    stats.orders,
+                    stats.pnl,
+                    stats.pnl_pct,
+                    stats.runtime_s,
+                    stats.wins,
+                    stats.losses,
+                ),
+            )
 
-    def get_bot_stats(self, bot_id: int) -> Optional[BotStats]:
-        return self._bot_stats.get(bot_id)
+    def get_bot_stats(self, bot_id: int, cycle: Optional[int] = None) -> Optional[BotStats]:
+        query = (
+            "SELECT bot_id, cycle_id, orders, pnl, pnl_pct, runtime_s, wins, losses "
+            "FROM bot_stats WHERE bot_id = ?"
+        )
+        params: List[Any] = [bot_id]
+        if cycle is not None:
+            query += " AND cycle_id = ?"
+            params.append(cycle)
+        query += " ORDER BY cycle_id DESC LIMIT 1"
+        row = self.conn.execute(query, params).fetchone()
+        if row is None:
+            return None
+        return BotStats(
+            bot_id=row["bot_id"],
+            cycle=row["cycle_id"],
+            orders=row["orders"],
+            pnl=row["pnl"],
+            pnl_pct=row["pnl_pct"],
+            runtime_s=row["runtime_s"],
+            wins=row["wins"],
+            losses=row["losses"],
+        )
 
-    def iter_stats(self) -> List[BotStats]:
-        return list(self._bot_stats.values())
+    def iter_stats(self, cycle: Optional[int] = None) -> List[BotStats]:
+        query = "SELECT bot_id, cycle_id, orders, pnl, pnl_pct, runtime_s, wins, losses FROM bot_stats"
+        params: List[Any] = []
+        if cycle is not None:
+            query += " WHERE cycle_id = ?"
+            params.append(cycle)
+        rows = self.conn.execute(query, params).fetchall()
+        return [
+            BotStats(
+                bot_id=r["bot_id"],
+                cycle=r["cycle_id"],
+                orders=r["orders"],
+                pnl=r["pnl"],
+                pnl_pct=r["pnl_pct"],
+                runtime_s=r["runtime_s"],
+                wins=r["wins"],
+                losses=r["losses"],
+            )
+            for r in rows
+        ]
 
-    # -- Ciclos --
+    # ------------------------------------------------------------------
+    # Orders
+    _ORDER_COLS = [
+        "order_id",
+        "bot_id",
+        "cycle_id",
+        "symbol",
+        "side",
+        "qty",
+        "price",
+        "fee_asset",
+        "fee_amount",
+        "ts",
+        "status",
+        "pnl",
+        "pnl_pct",
+        "notes",
+        "raw_json",
+        "expected_profit_ticks",
+        "actual_profit_ticks",
+        "spread_ticks",
+        "imbalance_pct",
+        "top3_depth",
+        "book_hash",
+        "latency_ms",
+        "cancel_replace_count",
+        "time_in_force",
+        "hold_time_s",
+    ]
+
+    def save_order(self, order: Dict[str, Any]) -> None:
+        values = [order.get(col) for col in self._ORDER_COLS]
+        placeholders = ",".join(["?"] * len(self._ORDER_COLS))
+        cols = ",".join(self._ORDER_COLS)
+        with self.conn:
+            self.conn.execute(
+                f"INSERT OR REPLACE INTO orders ({cols}) VALUES ({placeholders})",
+                values,
+            )
+
+    def iter_orders(
+        self, cycle: Optional[int] = None, bot_id: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        query = f"SELECT {', '.join(self._ORDER_COLS)} FROM orders"
+        params: List[Any] = []
+        clauses: List[str] = []
+        if cycle is not None:
+            clauses.append("cycle_id = ?")
+            params.append(cycle)
+        if bot_id is not None:
+            clauses.append("bot_id = ?")
+            params.append(bot_id)
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+        rows = self.conn.execute(query, params).fetchall()
+        return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Cycles
     def save_cycle_summary(self, cycle: int, summary: Dict[str, Any]) -> None:
-        self._cycle_summary[cycle] = summary
+        started_at = summary.get("started_at")
+        finished_at = summary.get("finished_at")
+        winner_bot_id = summary.get("winner_bot_id")
+        winner_reason = summary.get("winner_reason")
+        with self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO cycles (cycle_id, started_at, finished_at, winner_bot_id, winner_reason)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(cycle_id) DO UPDATE SET
+                    started_at=COALESCE(excluded.started_at, cycles.started_at),
+                    finished_at=COALESCE(excluded.finished_at, cycles.finished_at),
+                    winner_bot_id=excluded.winner_bot_id,
+                    winner_reason=excluded.winner_reason
+                """,
+                (cycle, started_at, finished_at, winner_bot_id, winner_reason),
+            )
 
     def get_cycle_summary(self, cycle: int) -> Optional[Dict[str, Any]]:
-        return self._cycle_summary.get(cycle)
+        row = self.conn.execute(
+            "SELECT cycle_id, started_at, finished_at, winner_bot_id, winner_reason FROM cycles WHERE cycle_id = ?",
+            (cycle,),
+        ).fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        self.conn.close()

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,68 @@
+CREATE TABLE IF NOT EXISTS cycles (
+    cycle_id INTEGER PRIMARY KEY,
+    started_at TEXT,
+    finished_at TEXT,
+    winner_bot_id INTEGER,
+    winner_reason TEXT
+);
+
+CREATE TABLE IF NOT EXISTS bots (
+    bot_id INTEGER PRIMARY KEY,
+    cycle_id INTEGER,
+    name TEXT,
+    seed_parent TEXT,
+    mutations_json TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS bot_stats (
+    bot_id INTEGER,
+    cycle_id INTEGER,
+    orders INTEGER,
+    pnl REAL,
+    pnl_pct REAL,
+    runtime_s INTEGER,
+    wins INTEGER,
+    losses INTEGER,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (bot_id, cycle_id)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    order_id TEXT PRIMARY KEY,
+    bot_id INTEGER,
+    cycle_id INTEGER,
+    symbol TEXT,
+    side TEXT,
+    qty REAL,
+    price REAL,
+    fee_asset TEXT,
+    fee_amount REAL,
+    ts TEXT,
+    status TEXT,
+    pnl REAL,
+    pnl_pct REAL,
+    notes TEXT,
+    raw_json TEXT,
+    expected_profit_ticks INTEGER,
+    actual_profit_ticks INTEGER,
+    spread_ticks REAL,
+    imbalance_pct REAL,
+    top3_depth TEXT,
+    book_hash TEXT,
+    latency_ms INTEGER,
+    cancel_replace_count INTEGER,
+    time_in_force TEXT,
+    hold_time_s REAL
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT,
+    level TEXT,
+    scope TEXT,
+    bot_id INTEGER,
+    cycle_id INTEGER,
+    message TEXT,
+    payload_json TEXT
+);


### PR DESCRIPTION
## Summary
- add BotRunner to execute strategy mutations asynchronously
- introduce parametrizable base strategy and mutation mapping utilities
- expose helper to instantiate engine with hooks; wire order callbacks in legacy engine
- create LLM client with initial-variation prompt and integrate into supervisor
- persist tournament data, orders and events in SQLite

## Testing
- `python -m py_compile TITAN-BOT/orchestrator/storage.py TITAN-BOT/orchestrator/__init__.py TITAN-BOT/orchestrator/supervisor.py TITAN-BOT/orchestrator/runner.py TITAN-BOT/engine/__init__.py TITAN-BOT/engine/strategy_base.py TITAN-BOT/engine/strategy_params.py TITAN-BOT/engine/legacy.py TITAN-BOT/llm/__init__.py TITAN-BOT/llm/client.py TITAN-BOT/llm/prompts.py`
- `python - <<'PY'
import asyncio, os, sqlite3
from orchestrator import Supervisor, SQLiteStorage, BotRunner, BotConfig
from engine.strategy_base import StrategyBase
from llm.client import LLMClient

async def run_tests():
    db_path = 'test.db'
    if os.path.exists(db_path):
        os.remove(db_path)
    storage = SQLiteStorage(db_path)
    sup = Supervisor(storage=storage)
    def fake_gen(self, spec):
        return [{"name": f"var-{i}", "mutations": {}} for i in range(10)]
    LLMClient.generate_initial_variations = fake_gen
    await sup.run_cycle(1)
    class MockExchange:
        async def get_order_book(self, symbol):
            return {"best_bid": 100.0, "best_ask": 100.1}
        async def create_limit_buy_order(self, symbol, amount, price):
            return {"id": f"b-{symbol}", "symbol": symbol, "amount": amount, "price": price}
        async def create_limit_sell_order(self, symbol, amount, price):
            return {"id": f"s-{symbol}", "symbol": symbol, "amount": amount, "price": price}
    exchange = MockExchange()
    strategy = StrategyBase(exchange)
    cfg = BotConfig(id=999, cycle=1, name='Bot-999', mutations={}, seed_parent=None)
    runner = BotRunner(cfg, {"max_orders": 10, "max_scans": 10, "max_llm_calls": 10}, exchange, strategy, storage)
    await runner.run()
    storage.close()
    conn = sqlite3.connect(db_path)
    cur = conn.cursor()
    print('cycles', cur.execute('SELECT count(*) FROM cycles').fetchone()[0])
    print('bots', cur.execute('SELECT count(*) FROM bots').fetchone()[0])
    print('bot_stats', cur.execute('SELECT count(*) FROM bot_stats').fetchone()[0])
    print('events', cur.execute('SELECT count(*) FROM events').fetchone()[0])
    print('orders', cur.execute('SELECT count(*) FROM orders').fetchone()[0])
    conn.close()
asyncio.run(run_tests())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a0ee92e0c4832886b71eefd9285a23