### PR TITLE
feat: add bot runner and base strategy

### DIFF
--- a/components/testeos_frame.py
+++ b/components/testeos_frame.py
@@ -1,10 +1,8 @@
-from typing import Callable
+from typing import Callable, Dict, Any
 
-import ttkbootstrap as tb
 from ttkbootstrap.constants import *
 from tkinter import ttk
 
-from orchestrator.models import SupervisorEvent
 
 class TesteosFrame(ttk.Frame):
     """Frame que muestra y controla los testeos masivos."""
@@ -13,11 +11,11 @@ class TesteosFrame(ttk.Frame):
         self,
         parent: ttk.Widget,
         on_toggle: Callable[[bool], None],
-        on_load_winner: Callable[[], None],
+        on_load_winner_for_sim: Callable[[], None],
     ) -> None:
         super().__init__(parent, padding=10)
         self._on_toggle = on_toggle
-        self._on_load_winner = on_load_winner
+        self._on_load_winner_for_sim = on_load_winner_for_sim
         self._running = False
         self._build()
 
@@ -25,6 +23,7 @@ class TesteosFrame(ttk.Frame):
         """Construye los widgets principales."""
         self.columnconfigure(0, weight=1)
         self.rowconfigure(1, weight=1)
+        self.rowconfigure(4, weight=1)
 
         self.btn_toggle = ttk.Button(
             self,
@@ -52,7 +51,27 @@ class TesteosFrame(ttk.Frame):
         self.tree.grid(row=1, column=0, sticky="nsew")
         vsb.grid(row=1, column=1, sticky="ns")
 
-        ttk.Button(self, text="Subir Bot Sim", command=self._on_load_winner).grid(row=2, column=0, sticky="w", pady=(8, 0))
+        ttk.Button(
+            self, text="Subir Bot Sim", command=self.on_load_winner_for_sim
+        ).grid(row=2, column=0, sticky="w", pady=(8, 0))
+
+        self.lbl_winner = ttk.Label(self, text="Ganador: -", anchor="w")
+        self.lbl_winner.grid(row=3, column=0, sticky="w", pady=(6, 0))
+
+        cols_c = ("cycle", "pnl", "winner", "fecha")
+        self.tree_cycles = ttk.Treeview(self, columns=cols_c, show="headings", height=5)
+        for c, txt, w in [
+            ("cycle", "Ciclo", 80),
+            ("pnl", "PNL Total", 100),
+            ("winner", "Ganador", 120),
+            ("fecha", "Fecha", 150),
+        ]:
+            self.tree_cycles.heading(c, text=txt)
+            self.tree_cycles.column(c, width=w, anchor="center", stretch=True)
+        vsb_c = ttk.Scrollbar(self, orient="vertical", command=self.tree_cycles.yview)
+        self.tree_cycles.configure(yscrollcommand=vsb_c.set)
+        self.tree_cycles.grid(row=4, column=0, sticky="nsew", pady=(8, 0))
+        vsb_c.grid(row=4, column=1, sticky="ns")
 
     def _toggle(self) -> None:
         """Alterna el estado de los testeos y actualiza el botón."""
@@ -67,39 +86,53 @@ class TesteosFrame(ttk.Frame):
             pass
 
     # ------------------------------------------------------------------
-    def handle_event(self, event: SupervisorEvent) -> None:
-        """Actualiza la tabla según los eventos del supervisor."""
+    def clear(self) -> None:
+        """Elimina todas las filas del árbol."""
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+
+    def update_bot_row(self, stats: Dict[str, Any]) -> None:
+        """Inserta o actualiza una fila con estadísticas de un bot."""
+        bot_id = int(stats.get("bot_id"))
+        cycle = stats.get("cycle", "")
+        orders = stats.get("orders", 0)
+        pnl = stats.get("pnl", 0.0)
+        status = stats.get("status", "")
+        is_winner = stats.get("winner", False)
+        values = (
+            bot_id,
+            cycle,
+            orders,
+            f"{pnl:+.2f}",
+            status,
+            "✅" if is_winner else "",
+        )
+        if self.tree.exists(str(bot_id)):
+            self.tree.item(str(bot_id), values=values)
+        else:
+            self.tree.insert("", "end", iid=str(bot_id), values=values)
+
+    def set_winner(self, bot_id: int, reason: str) -> None:
+        """Marca el bot ganador y muestra la razón."""
+        if self.tree.exists(str(bot_id)):
+            vals = list(self.tree.item(str(bot_id), "values"))
+            vals[-1] = "✅"
+            self.tree.item(str(bot_id), values=vals)
+        self.lbl_winner.configure(text=f"Ganador: Bot {bot_id} - {reason}")
+
+    def add_cycle_history(self, info: Dict[str, Any]) -> None:
+        """Agrega una fila al historial de ciclos."""
+        values = (
+            info.get("cycle"),
+            f"{info.get('total_pnl', 0.0):+.2f}",
+            f"Bot {info.get('winner_id')}",
+            info.get("finished_at", ""),
+        )
+        self.tree_cycles.insert("", "end", values=values)
+
+    def on_load_winner_for_sim(self) -> None:
+        """Invoca el callback para cargar el bot ganador en modo SIM."""
         try:
-            if event.message == "cycle_start":
-                for item in self.tree.get_children():
-                    self.tree.delete(item)
-            elif event.message == "bot_start":
-                self.tree.insert(
-                    "",
-                    "end",
-                    iid=str(event.bot_id),
-                    values=(event.bot_id, event.cycle, "", "", "RUNNING", ""),
-                )
-            elif event.message == "bot_finished" and event.payload:
-                stats = event.payload.get("stats", {})
-                pnl = stats.get("pnl", 0.0)
-                orders = stats.get("orders", 0)
-                self.tree.item(
-                    str(event.bot_id),
-                    values=(
-                        event.bot_id,
-                        event.cycle,
-                        orders,
-                        f"{pnl:+.2f}",
-                        "DONE",
-                        "",
-                    ),
-                )
-            elif event.message == "cycle_winner" and event.payload:
-                winner_id = event.payload.get("winner_id")
-                if winner_id is not None and self.tree.exists(str(winner_id)):
-                    vals = list(self.tree.item(str(winner_id), "values"))
-                    vals[-1] = "✅"
-                    self.tree.item(str(winner_id), values=vals)
+            self._on_load_winner_for_sim()
         except Exception:
             pass

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,41 @@
+"""Trading engine package exposing strategy utilities and helpers."""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from .legacy import Engine
+from .strategy_base import StrategyBase
+from .strategy_params import map_mutations_to_params
+
+
+def create_engine(
+    exchange: Optional[Any] = None,
+    config_overrides: Optional[Dict[str, Any]] = None,
+    mutations: Optional[Dict[str, Any]] = None,
+    on_order: Optional[Callable[[Dict[str, Any]], None]] = None,
+) -> Engine:
+    """Instantiate :class:`Engine` applying overrides and hooks."""
+    engine = Engine(ui_push_snapshot=lambda _: None, exchange=exchange)
+    if config_overrides:
+        for key, value in config_overrides.items():
+            setattr(engine.cfg, key, value)
+    engine.mutations = mutations or {}
+    if on_order:
+        engine.set_order_hook(on_order)
+    return engine
+
+
+def load_sim_config(mutations: Dict[str, Any]) -> Engine:
+    """Create a SIM engine applying strategy mutations."""
+    params = map_mutations_to_params(mutations)
+    overrides = {k: getattr(params, k) for k in ("order_size_usd",)}
+    return create_engine(config_overrides=overrides, mutations=mutations)
+
+
+__all__ = [
+    "Engine",
+    "StrategyBase",
+    "map_mutations_to_params",
+    "create_engine",
+    "load_sim_config",
+]

--- a/engine/strategy_base.py
+++ b/engine/strategy_base.py
@@ -1,0 +1,91 @@
+"""Parameter driven implementation of the original BTC strategy."""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, Iterable, List, Tuple
+
+from .strategy_params import Params
+
+
+class StrategyBase:
+    """Execute the base BTC strategy under mutable parameters."""
+
+    def __init__(self, exchange: Any) -> None:
+        self.exchange = exchange
+
+    async def select_pairs(self, params: Params) -> List[str]:
+        """Return symbols that meet profitability and volume constraints."""
+        markets = await self.exchange.get_markets()
+        symbols: List[Tuple[str, float]] = []
+        for sym, info in markets.items():
+            if not sym.endswith("BTC"):
+                continue
+            tick = float(info.get("price_increment", 1e-8))
+            fees = float(info.get("maker", 0.001)) + float(info.get("taker", 0.001))
+            ticker = await self.exchange.get_ticker(sym)
+            last = float(ticker.get("last", 0.0))
+            vol = float(ticker.get("base_volume", 0.0))
+            if vol < params.min_vol_btc_24h:
+                continue
+            fees_ticks = (last * fees) / tick if tick else 0.0
+            if 1 <= fees_ticks + params.commission_buffer_ticks:
+                continue
+            symbols.append((sym, last))
+        symbols.sort(key=lambda x: x[1])
+        return [s for s, _ in symbols]
+
+    async def place_buy(self, params: Params, symbol: str) -> Dict[str, Any]:
+        """Place a buy on the best ask when bid imbalance is high."""
+        book = await self.exchange.get_order_book(symbol)
+        bids = book.get("bids", [])
+        asks = book.get("asks", [])
+        bid_price, bid_qty = bids[0]
+        ask_price, ask_qty = asks[0]
+        imbalance = bid_qty / (bid_qty + ask_qty) * 100 if (bid_qty + ask_qty) else 0
+        if imbalance < params.imbalance_buy_threshold_pct:
+            raise RuntimeError("bid imbalance too low")
+        info = await self.exchange.get_market(symbol)
+        tick = float(info.get("price_increment", 1e-8))
+        amount = params.order_size_usd / ask_price
+        spread_ticks = (ask_price - bid_price) / tick if tick else 0.0
+        order = await self.exchange.create_limit_buy_order(symbol, amount, ask_price)
+        order.update({"imbalance_pct": imbalance, "spread_ticks": spread_ticks, "tick_size": tick})
+        return order
+
+    async def place_sell_plus_ticks(self, params: Params, symbol: str, buy_order: Dict[str, Any]) -> Dict[str, Any]:
+        """Sell ``sell_k_ticks`` above the buy price."""
+        tick = buy_order.get("tick_size") or (await self.exchange.get_market(symbol)).get("price_increment", 1e-8)
+        price = buy_order["price"] + tick * params.sell_k_ticks
+        amount = buy_order["amount"]
+        order = await self.exchange.create_limit_sell_order(symbol, amount, price)
+        return order
+
+    async def monitor_and_adjust(
+        self,
+        params: Params,
+        orders: List[Tuple[Dict[str, Any], Dict[str, Any]]],
+        order_book_provider: Any,
+    ) -> List[Dict[str, Any]]:
+        """Monitor until filled or timeout, returning PNL and metrics."""
+        updates: List[Dict[str, Any]] = []
+        start = time.time()
+        for buy, sell in orders:
+            await asyncio.sleep(0)  # simulation: instant fills
+            hold = time.time() - start
+            pnl = (sell["price"] - buy["price"]) * buy["amount"]
+            notional = buy["price"] * buy["amount"]
+            pnl_pct = (pnl / notional * 100.0) if notional else 0.0
+            updates.append(
+                {
+                    "symbol": buy["symbol"],
+                    "pnl": pnl,
+                    "pnl_pct": pnl_pct,
+                    "imbalance_pct": buy.get("imbalance_pct"),
+                    "spread_ticks": buy.get("spread_ticks"),
+                    "hold_time_s": hold,
+                    "cancel_replace_count": 0,
+                }
+            )
+        return updates
+

--- a/engine/strategy_params.py
+++ b/engine/strategy_params.py
@@ -1,0 +1,99 @@
+"""Mapping from mutation dictionaries to validated strategy parameters."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class CancelReplaceRules:
+    """Rules controlling order cancel/replace behaviour."""
+
+    enable: bool = False
+    max_moves: int = 0
+    min_depth_ratio: float = 0.5
+
+
+@dataclass
+class RiskLimits:
+    """Simple risk guard rails for the strategy."""
+
+    max_open_orders: int = 1
+    per_pair_exposure_usd: float = 100.0
+
+
+@dataclass
+class Params:
+    """Concrete parameters consumed by :mod:`strategy_base`."""
+
+    order_size_usd: float = 50.0
+    buy_level_rule: str = "accum_bids"
+    sell_k_ticks: int = 1
+    max_wait_s: int = 30
+    imbalance_buy_threshold_pct: float = 20.0
+    cancel_replace_rules: CancelReplaceRules = field(default_factory=CancelReplaceRules)
+    pair_ranking_window_s: int = 60
+    min_vol_btc_24h: float = 10.0
+    commission_buffer_ticks: int = 1
+    risk_limits: RiskLimits = field(default_factory=RiskLimits)
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def map_mutations_to_params(mutations: Dict[str, Any] | None) -> Params:
+    """Translate mutation dictionaries into :class:`Params`.
+
+    Unknown keys are ignored. Basic validation/clamping is applied so the
+    resulting parameters are always sane for the strategy.
+    """
+
+    params = Params()
+    if not mutations:
+        return params
+
+    if "order_size_usd" in mutations:
+        try:
+            params.order_size_usd = float(mutations["order_size_usd"])
+        except (TypeError, ValueError):
+            pass
+
+    if mutations.get("sell_rule") == "+k_ticks":
+        params.sell_k_ticks = int(mutations.get("k_ticks", params.sell_k_ticks))
+        params.max_wait_s = int(mutations.get("max_wait_s", params.max_wait_s))
+
+    if "imbalance_buy_threshold_pct" in mutations:
+        pct = float(mutations["imbalance_buy_threshold_pct"])
+        params.imbalance_buy_threshold_pct = _clamp(pct, 0.0, 100.0)
+
+    if "pair_ranking_window_s" in mutations:
+        params.pair_ranking_window_s = int(mutations["pair_ranking_window_s"])
+
+    if "min_vol_btc_24h" in mutations:
+        params.min_vol_btc_24h = float(mutations["min_vol_btc_24h"])
+
+    if "commission_buffer_ticks" in mutations:
+        params.commission_buffer_ticks = int(mutations["commission_buffer_ticks"])
+
+    cr = mutations.get("cancel_replace_rules")
+    if isinstance(cr, dict):
+        params.cancel_replace_rules.enable = bool(cr.get("enable", params.cancel_replace_rules.enable))
+        params.cancel_replace_rules.max_moves = int(cr.get("max_moves", params.cancel_replace_rules.max_moves))
+        params.cancel_replace_rules.min_depth_ratio = float(
+            cr.get("min_depth_ratio", params.cancel_replace_rules.min_depth_ratio)
+        )
+
+    rl = mutations.get("risk_limits")
+    if isinstance(rl, dict):
+        params.risk_limits.max_open_orders = int(
+            rl.get("max_open_orders", params.risk_limits.max_open_orders)
+        )
+        params.risk_limits.per_pair_exposure_usd = float(
+            rl.get("per_pair_exposure_usd", params.risk_limits.per_pair_exposure_usd)
+        )
+
+    return params
+
+
+__all__ = ["Params", "CancelReplaceRules", "RiskLimits", "map_mutations_to_params"]

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,0 +1,4 @@
+"""LLM helpers package."""
+from .client import LLMClient
+
+__all__ = ["LLMClient"]

--- a/llm/client.py
+++ b/llm/client.py
@@ -1,0 +1,282 @@
+"""Cliente LLM para generar variaciones de estrategia."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List, Optional
+import hashlib
+
+from .prompts import (
+    PROMPT_INICIAL_VARIACIONES,
+    PROMPT_ANALISIS_CICLO,
+    PROMPT_NUEVA_GENERACION_DESDE_GANADOR,
+)
+
+
+class LLMClient:
+    """Wrapper liviano sobre OpenAI que genera variaciones iniciales.
+
+    Si no hay clave de API o falla la llamada, devuelve un conjunto
+    determinista de 10 variaciones válidas.
+    """
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "gpt-4o-mini") -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY", "")
+        self.model = model
+        self._client = None
+        if self.api_key:
+            try:  # Lazy import para no requerir dependencia siempre
+                from openai import OpenAI  # type: ignore
+
+                self._client = OpenAI(api_key=self.api_key)
+            except Exception:
+                self._client = None
+
+    # ------------------------------------------------------------------
+    def _call_openai(self, trading_spec_text: str) -> List[Dict[str, object]]:
+        assert self._client is not None
+        resp = self._client.chat.completions.create(
+            model=self.model,
+            temperature=0.2,
+            messages=[
+                {"role": "system", "content": PROMPT_INICIAL_VARIACIONES},
+                {"role": "user", "content": trading_spec_text},
+            ],
+            timeout=40,
+        )
+        txt = resp.choices[0].message.content or "[]"
+        data = json.loads(txt)
+        if not isinstance(data, list):
+            raise ValueError("respuesta no es lista")
+        return data
+
+    # ------------------------------------------------------------------
+    def _fallback_variations(self) -> List[Dict[str, object]]:
+        """Genera 10 variaciones deterministas para modo sin LLM."""
+        variations: List[Dict[str, object]] = []
+        for i in range(10):
+            variations.append(
+                {
+                    "name": f"var-{i+1:02d}",
+                    "mutations": {
+                        "order_size_usd": "auto",
+                        "buy_level_rule": "accum_bids",
+                        "sell_rule": "+1_tick",
+                        "imbalance_buy_threshold_pct": 15 + i,
+                        "cancel_replace_rules": {
+                            "enable": True,
+                            "max_moves": i % 5,
+                            "min_depth_ratio": 0.5 + (i % 3) * 0.1,
+                        },
+                        "pair_ranking_window_s": 10 + i,
+                        "min_vol_btc_24h": 5 + i,
+                        "commission_buffer_ticks": 1,
+                        "risk_limits": {
+                            "max_open_orders": 1 + (i % 5),
+                            "per_pair_exposure_usd": 50 + i * 10,
+                        },
+                    },
+                }
+            )
+        return variations
+
+    # ------------------------------------------------------------------
+    def generate_initial_variations(self, trading_spec_text: str) -> List[Dict[str, object]]:
+        """Obtiene 10 variaciones únicas de la estrategia base."""
+        raw: List[Dict[str, object]] = []
+        if self._client is not None:
+            try:
+                raw = self._call_openai(trading_spec_text)
+            except Exception:
+                raw = []
+        if not raw:
+            raw = self._fallback_variations()
+
+        unique: List[Dict[str, object]] = []
+        seen = set()
+        for item in raw:
+            name = str(item.get("name")) if isinstance(item, dict) else ""
+            muts = item.get("mutations") if isinstance(item, dict) else None
+            if not name or not isinstance(muts, dict):
+                continue
+            key = json.dumps(muts, sort_keys=True)
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append({"name": name, "mutations": muts})
+            if len(unique) == 10:
+                break
+
+        # Asegurar 10 variaciones
+        idx = 1
+        while len(unique) < 10:
+            extra_name = f"auto-{idx:02d}"
+            key = json.dumps({"placeholder": idx})
+            if key not in seen:
+                unique.append({"name": extra_name, "mutations": {}})
+                seen.add(key)
+            idx += 1
+        return unique
+
+    # ------------------------------------------------------------------
+    def _fingerprint(self, mutations: Dict[str, object]) -> str:
+        """Genera un hash determinista para un conjunto de mutations."""
+        return hashlib.sha256(json.dumps(mutations, sort_keys=True).encode()).hexdigest()
+
+    # ------------------------------------------------------------------
+    def _fallback_new_generation(
+        self,
+        winner_mutations: Dict[str, object],
+        history_fingerprints: List[str],
+    ) -> List[Dict[str, object]]:
+        """Crea 10 variaciones simples basadas en el ganador.
+
+        Cada variación modifica ligeramente ``imbalance_buy_threshold_pct`` y
+        ``max_open_orders`` respetando los fingerprints históricos.
+        """
+
+        base = winner_mutations.copy()
+        variations: List[Dict[str, object]] = []
+        seen = set(history_fingerprints)
+        for i in range(1, 21):  # margen para asegurar 10
+            muts = json.loads(json.dumps(base))  # deep copy
+            thresh = muts.get("imbalance_buy_threshold_pct", 20)
+            if isinstance(thresh, (int, float)):
+                muts["imbalance_buy_threshold_pct"] = int(thresh) + i
+            rl = muts.get("risk_limits", {})
+            if isinstance(rl, dict):
+                moo = rl.get("max_open_orders", 1)
+                if isinstance(moo, int):
+                    rl["max_open_orders"] = max(1, moo + (i % 3))
+                rl.setdefault("per_pair_exposure_usd", 50)
+                muts["risk_limits"] = rl
+            fp = self._fingerprint(muts)
+            if fp in seen:
+                continue
+            seen.add(fp)
+            variations.append({"name": f"child-{i:02d}", "mutations": muts})
+            if len(variations) == 10:
+                break
+        return variations
+
+    # ------------------------------------------------------------------
+    def new_generation_from_winner(
+        self,
+        winner_mutations: Dict[str, object],
+        history_fingerprints: List[str],
+    ) -> List[Dict[str, object]]:
+        """Genera 10 variaciones nuevas basadas en el ganador anterior.
+
+        ``history_fingerprints`` contiene hashes de mutaciones previas para
+        evitar duplicados históricos.
+        """
+
+        raw: List[Dict[str, object]] = []
+        if self._client is not None:
+            prompt = PROMPT_NUEVA_GENERACION_DESDE_GANADOR.replace(
+                "<PEGAR_JSON_WINNER>", json.dumps(winner_mutations, ensure_ascii=False)
+            )
+            try:
+                resp = self._client.chat.completions.create(
+                    model=self.model,
+                    temperature=0.2,
+                    messages=[
+                        {"role": "system", "content": prompt},
+                        {
+                            "role": "user",
+                            "content": json.dumps({"history_fingerprints": history_fingerprints}),
+                        },
+                    ],
+                    timeout=40,
+                )
+                txt = resp.choices[0].message.content or "[]"
+                raw = json.loads(txt)
+                if not isinstance(raw, list):
+                    raw = []
+            except Exception:
+                raw = []
+        if not raw:
+            raw = self._fallback_new_generation(winner_mutations, history_fingerprints)
+
+        unique: List[Dict[str, object]] = []
+        seen = set(history_fingerprints)
+        for item in raw:
+            name = str(item.get("name")) if isinstance(item, dict) else ""
+            muts = item.get("mutations") if isinstance(item, dict) else None
+            if not name or not isinstance(muts, dict):
+                continue
+            fp = self._fingerprint(muts)
+            if fp in seen:
+                continue
+            seen.add(fp)
+            unique.append({"name": name, "mutations": muts})
+            if len(unique) == 10:
+                break
+
+        # rellenar si faltan
+        idx = 1
+        while len(unique) < 10:
+            base = json.loads(json.dumps(winner_mutations))
+            base["placeholder"] = idx
+            fp = self._fingerprint(base)
+            if fp not in seen:
+                unique.append({"name": f"auto-{idx:02d}", "mutations": base})
+                seen.add(fp)
+            idx += 1
+        return unique
+
+    # ------------------------------------------------------------------
+    def analyze_cycle_and_pick_winner(self, cycle_summary: Dict[str, object]) -> Dict[str, object]:
+        """Analiza un resumen de ciclo y elige un ganador.
+
+        Si la llamada al LLM falla o no hay API key, se usa como
+        fallback el bot con mayor PNL.
+        """
+
+        if self._client is not None:
+            try:
+                resp = self._client.chat.completions.create(
+                    model=self.model,
+                    temperature=0,
+                    messages=[
+                        {"role": "system", "content": PROMPT_ANALISIS_CICLO},
+                        {"role": "user", "content": json.dumps(cycle_summary)},
+                    ],
+                    timeout=40,
+                )
+                txt = resp.choices[0].message.content or "{}"
+                data = json.loads(txt)
+                if isinstance(data, dict) and "winner_bot_id" in data:
+                    return {
+                        "winner_bot_id": int(data["winner_bot_id"]),
+                        "reason": str(data.get("reason", "")),
+                    }
+            except Exception:
+                pass
+        return self._fallback_winner(cycle_summary)
+
+    # ------------------------------------------------------------------
+    def _fallback_winner(self, cycle_summary: Dict[str, object]) -> Dict[str, object]:
+        """Fallback determinista seleccionando el bot con mayor PnL.
+
+        Se recorre la lista de bots provista en ``cycle_summary`` y se
+        identifica el ``bot_id`` con mayor beneficio acumulado. Este camino
+        es utilizado cuando la llamada al LLM falla o no se dispone de clave
+        de API, evitando que el ciclo quede sin ganador.
+        """
+
+        bots = cycle_summary.get("bots", [])
+        best_id = None
+        best_pnl = float("-inf")
+        for bot in bots:
+            try:
+                pnl = float(bot.get("stats", {}).get("pnl", float("-inf")))
+            except Exception:
+                pnl = float("-inf")
+            if pnl > best_pnl:
+                best_pnl = pnl
+                best_id = bot.get("bot_id")
+        return {
+            "winner_bot_id": int(best_id) if best_id is not None else -1,
+            "reason": "max_pnl",
+        }

--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -1,0 +1,48 @@
+"""Prompts estáticos usados por el cliente LLM."""
+
+PROMPT_INICIAL_VARIACIONES = """
+SISTEMA: Eres experto en microestructura y market-making spot en Binance (pares XXXBTC). Tarea: generar 10 variaciones de una estrategia base que compra en nivel con acumulación de bids y vende +1 tick, con filtros: beneficio > comisiones (compra+venta), volumen ≥ 5 BTC/24h y monitoreo del libro para mover/cancelar órdenes ante cambios.
+REQUISITOS:
+- 10 variaciones distintas entre sí (sin duplicados lógicos).
+- Cambia exactamente 1–3 elementos por variación: umbrales de desequilibrio, reglas de entrada/salida, ventana de ranking, límites de exposición, tamaño de orden, cancel/replace, timeout de venta, criterio de venta al precio de compra ante caída del 15%, etc.
+- Mantén el espíritu del método original (venta +1 tick) aunque se permitan “+k_ticks con max_wait_s”.
+FORMATO DE SALIDA:
+Devuelve un JSON array con 10 objetos, cada uno con:
+{
+  "name": "var-<corto-unico>",
+  "mutations": {
+    "order_size_usd": "auto|fijo|%balance",
+    "buy_level_rule": "accum_bids|best_ask_if_imbalance",
+    "sell_rule": "+1_tick|+k_ticks|max_wait_s",
+    "imbalance_buy_threshold_pct": <15-40>,
+    "cancel_replace_rules": {"enable": true, "max_moves": 0-5, "min_depth_ratio": 0.4-0.9},
+    "pair_ranking_window_s": <10-120>,
+    "min_vol_btc_24h": <5-50>,
+    "commission_buffer_ticks": <1-3>,
+    "risk_limits": {"max_open_orders": 1-5, "per_pair_exposure_usd": 10-500}
+  }
+}
+CONSTRICCIONES:
+- Sin dos variaciones con el mismo set efectivo de mutations.
+- Sin ML.
+- Todas aplicables a cualquier XXXBTC independientemente del precio (usar increments del exchange si aplica).
+Valida que el JSON sea parseable.
+"""
+
+PROMPT_ANALISIS_CICLO = """
+Te paso un resumen del ciclo con 10 bots. Para cada bot: mutations, stats (orders, pnl, pnl_pct, win_rate, avg_hold_s, avg_slippage_ticks, timeouts, cancel_replace_count), top-3 pares por PnL, distribución de resultados por hora.
+Tarea: Elige UN ganador priorizando PNL y estabilidad (menor varianza y menos timeouts/slippage). Penaliza configuraciones con drawdowns altos o comportamiento errático. Devuelve JSON:
+{ "winner_bot_id": <int>, "reason": "<breve explicación>" }
+El JSON debe ser parseable. Nada más.
+"""
+
+PROMPT_NUEVA_GENERACION_DESDE_GANADOR = """
+Base (JSON mutations) del bot ganador:
+<PEGAR_JSON_WINNER>
+Genera 10 NUEVAS variaciones cercanas (mutaciones locales pequeñas), todas distintas entre sí y distintas a cualquier variación previa (te paso fingerprints si los hay). Respeta:
+- Sin ML.
+- Par BTC.
+- Regla central de venta +1 tick puede extenderse a +k_ticks con max_wait_s, siempre cubriendo comisiones.
+Formato: igual que el prompt inicial (name + mutations). Devuelve JSON parseable.
+Evita duplicados: usa fingerprints (hashes) de conjuntos de parámetros que te paso.
+"""

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,14 @@
+"""Helper exports for orchestrator package."""
+from .models import BotConfig, BotStats, SupervisorEvent
+from .runner import BotRunner
+from .storage import SQLiteStorage
+from .supervisor import Supervisor
+
+__all__ = [
+    "BotRunner",
+    "Supervisor",
+    "BotConfig",
+    "BotStats",
+    "SupervisorEvent",
+    "SQLiteStorage",
+]

--- a/orchestrator/runner.py
+++ b/orchestrator/runner.py
@@ -1,0 +1,173 @@
+"""Asynchronous runner executing a single bot instance."""
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from .models import BotConfig, BotStats
+from engine.strategy_base import StrategyBase
+from engine.strategy_params import map_mutations_to_params, Params
+
+
+class BotRunner:
+    """Run a trading bot applying parameter mutations."""
+
+    def __init__(
+        self,
+        config: BotConfig,
+        limits: Dict[str, int],
+        exchange: Any,
+        strategy: StrategyBase,
+        storage: Any,
+        ui_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> None:
+        self.config = config
+        self.limits = limits
+        self.exchange = exchange
+        self.strategy = strategy
+        self.storage = storage
+        self.ui_callback = ui_callback or (lambda _: None)
+
+    async def run(self) -> BotStats:
+        """Execute the bot respecting the provided limits."""
+        params: Params = map_mutations_to_params(self.config.mutations)
+        start = time.time()
+        orders_count = 0
+        wins = 0
+        losses = 0
+        pnl = 0.0
+
+        symbols = await self.strategy.select_pairs(params)
+        scans = 1
+        if self.limits.get("max_scans") is not None and scans > self.limits["max_scans"]:
+            raise RuntimeError("scan limit exceeded")
+
+        open_orders: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+        for sym in symbols:
+            if orders_count + 2 > self.limits.get("max_orders", float("inf")):
+                break
+            buy = await self.strategy.place_buy(params, sym)
+            expected_ticks = params.sell_k_ticks
+            self.storage.save_order(
+                {
+                    "order_id": buy.get("id"),
+                    "bot_id": self.config.id,
+                    "cycle_id": self.config.cycle,
+                    "symbol": buy.get("symbol", sym),
+                    "side": "buy",
+                    "qty": buy.get("amount"),
+                    "price": buy.get("price"),
+                    "resulting_fill_price": None,
+                    "fee_asset": None,
+                    "fee_amount": None,
+                    "ts": datetime.utcnow().isoformat(),
+                    "status": "open",
+                    "pnl": None,
+                    "pnl_pct": None,
+                    "expected_profit_ticks": expected_ticks,
+                    "actual_profit_ticks": None,
+                    "spread_ticks": buy.get("spread_ticks"),
+                    "imbalance_pct": buy.get("imbalance_pct"),
+                    "top3_depth": json.dumps(buy.get("top3_depth")) if buy.get("top3_depth") else None,
+                    "book_hash": buy.get("book_hash"),
+                    "latency_ms": buy.get("latency_ms"),
+                    "cancel_replace_count": 0,
+                    "time_in_force": buy.get("time_in_force"),
+                    "hold_time_s": None,
+                    "raw_json": json.dumps(buy),
+                }
+            )
+            sell = await self.strategy.place_sell_plus_ticks(params, sym, buy)
+            self.storage.save_order(
+                {
+                    "order_id": sell.get("id"),
+                    "bot_id": self.config.id,
+                    "cycle_id": self.config.cycle,
+                    "symbol": sell.get("symbol", sym),
+                    "side": "sell",
+                    "qty": sell.get("amount"),
+                    "price": sell.get("price"),
+                    "resulting_fill_price": None,
+                    "fee_asset": None,
+                    "fee_amount": None,
+                    "ts": datetime.utcnow().isoformat(),
+                    "status": "open",
+                    "pnl": None,
+                    "pnl_pct": None,
+                    "expected_profit_ticks": expected_ticks,
+                    "actual_profit_ticks": None,
+                    "spread_ticks": buy.get("spread_ticks"),
+                    "imbalance_pct": buy.get("imbalance_pct"),
+                    "top3_depth": None,
+                    "book_hash": None,
+                    "latency_ms": None,
+                    "cancel_replace_count": 0,
+                    "time_in_force": sell.get("time_in_force"),
+                    "hold_time_s": None,
+                    "raw_json": json.dumps(sell),
+                }
+            )
+            open_orders.append((buy, sell))
+            orders_count += 2
+
+        updates = await self.strategy.monitor_and_adjust(
+            params, open_orders, self.exchange.get_order_book
+        )
+        for (buy, sell), upd in zip(open_orders, updates):
+            pnl += upd.get("pnl", 0.0)
+            if upd.get("pnl", 0.0) >= 0:
+                wins += 1
+            else:
+                losses += 1
+            tick = buy.get("tick_size") or 1
+            expected_ticks = params.sell_k_ticks
+            actual_ticks = int(round((sell["price"] - buy["price"]) / tick))
+            for side, order in (("buy", buy), ("sell", sell)):
+                data = {
+                    "order_id": order.get("id"),
+                    "bot_id": self.config.id,
+                    "cycle_id": self.config.cycle,
+                    "symbol": order.get("symbol"),
+                    "side": side,
+                    "qty": order.get("amount"),
+                    "price": order.get("price"),
+                    "resulting_fill_price": order.get("price"),
+                    "fee_asset": (order.get("fee") or {}).get("currency"),
+                    "fee_amount": (order.get("fee") or {}).get("cost"),
+                    "ts": datetime.utcnow().isoformat(),
+                    "status": "filled",
+                    "pnl": upd.get("pnl") if side == "sell" else None,
+                    "pnl_pct": upd.get("pnl_pct") if side == "sell" else None,
+                    "expected_profit_ticks": expected_ticks,
+                    "actual_profit_ticks": actual_ticks if side == "sell" else None,
+                    "spread_ticks": upd.get("spread_ticks"),
+                    "imbalance_pct": upd.get("imbalance_pct"),
+                    "top3_depth": json.dumps(upd.get("top3_depth")) if upd.get("top3_depth") else None,
+                    "book_hash": upd.get("book_hash"),
+                    "latency_ms": upd.get("latency_ms"),
+                    "cancel_replace_count": upd.get("cancel_replace_count"),
+                    "time_in_force": order.get("time_in_force"),
+                    "hold_time_s": upd.get("hold_time_s"),
+                    "raw_json": json.dumps(order),
+                }
+                self.storage.save_order(data)
+            self.ui_callback({"bot_id": self.config.id, **upd})
+
+        runtime_s = int(time.time() - start)
+        notional = params.order_size_usd * (orders_count / 2)
+        pnl_pct = (pnl / notional * 100.0) if notional else 0.0
+
+        stats = BotStats(
+            bot_id=self.config.id,
+            cycle=self.config.cycle,
+            orders=orders_count,
+            pnl=pnl,
+            pnl_pct=pnl_pct,
+            runtime_s=runtime_s,
+            wins=wins,
+            losses=losses,
+        )
+        self.storage.save_bot_stats(stats)
+        return stats

--- a/orchestrator/storage.py
+++ b/orchestrator/storage.py
@@ -1,47 +1,317 @@
-"""Almacenamiento en memoria para el orquestador."""
+"""SQLite-backed persistence layer for the orchestrator."""
 from __future__ import annotations
 
+import json
+import sqlite3
+import threading
+from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .models import BotConfig, BotStats, SupervisorEvent
 
+DB_FILENAME = "titanbot.db"
 
-class InMemoryStorage:
-    """Persistencia simple utilizando estructuras en memoria."""
 
-    def __init__(self) -> None:
-        self._events: List[SupervisorEvent] = []
-        self._bots: Dict[int, BotConfig] = {}
-        self._bot_stats: Dict[int, BotStats] = {}
-        self._cycle_summary: Dict[int, Dict[str, Any]] = {}
+class SQLiteStorage:
+    """Persist data from supervisors and runners into SQLite."""
 
-    # -- Eventos --
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = db_path or DB_FILENAME
+        # allow cross-thread usage (UI thread spawns supervisor thread)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self.conn.row_factory = sqlite3.Row
+        self._lock = threading.Lock()
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    def _init_db(self) -> None:
+        """Create tables if they do not yet exist."""
+        schema_path = Path(__file__).resolve().parent.parent / "schema.sql"
+        with open(schema_path, "r", encoding="utf-8") as fh:
+            self.conn.executescript(fh.read())
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    # Events
     def append_event(self, event: SupervisorEvent) -> None:
-        self._events.append(event)
+        with self._lock, self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO events (ts, level, scope, bot_id, cycle_id, message, payload_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.ts.isoformat(),
+                    event.level,
+                    event.scope,
+                    event.bot_id,
+                    event.cycle,
+                    event.message,
+                    json.dumps(event.payload) if event.payload else None,
+                ),
+            )
 
-    def get_events(self) -> List[SupervisorEvent]:
-        return list(self._events)
+    def get_events(self, cycle: Optional[int] = None) -> List[SupervisorEvent]:
+        query = "SELECT ts, level, scope, bot_id, cycle_id, message, payload_json FROM events"
+        params: List[Any] = []
+        if cycle is not None:
+            query += " WHERE cycle_id = ?"
+            params.append(cycle)
+        with self._lock:
+            rows = self.conn.execute(query, params).fetchall()
+        events = []
+        for row in rows:
+            payload = json.loads(row["payload_json"]) if row["payload_json"] else None
+            events.append(
+                SupervisorEvent(
+                    ts=datetime.fromisoformat(row["ts"]),
+                    level=row["level"],
+                    scope=row["scope"],
+                    cycle=row["cycle_id"],
+                    bot_id=row["bot_id"],
+                    message=row["message"],
+                    payload=payload,
+                )
+            )
+        return events
 
-    # -- Bots --
+    # ------------------------------------------------------------------
+    # Bots
     def save_bot(self, bot_config: BotConfig) -> None:
-        self._bots[bot_config.id] = bot_config
+        with self._lock, self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO bots (bot_id, cycle_id, name, seed_parent, mutations_json, created_at)
+                VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                ON CONFLICT(bot_id) DO UPDATE SET
+                    cycle_id=excluded.cycle_id,
+                    name=excluded.name,
+                    seed_parent=excluded.seed_parent,
+                    mutations_json=excluded.mutations_json
+                """,
+                (
+                    bot_config.id,
+                    bot_config.cycle,
+                    bot_config.name,
+                    bot_config.seed_parent,
+                    json.dumps(bot_config.mutations),
+                ),
+            )
 
     def get_bot(self, bot_id: int) -> Optional[BotConfig]:
-        return self._bots.get(bot_id)
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT bot_id, cycle_id, name, seed_parent, mutations_json FROM bots WHERE bot_id = ?",
+                (bot_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return BotConfig(
+            id=row["bot_id"],
+            cycle=row["cycle_id"],
+            name=row["name"],
+            mutations=json.loads(row["mutations_json"]) if row["mutations_json"] else {},
+            seed_parent=row["seed_parent"],
+        )
 
-    # -- Stats --
+    def iter_bots(self) -> List[BotConfig]:
+        """Return all stored bot configurations."""
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT bot_id, cycle_id, name, seed_parent, mutations_json FROM bots"
+            ).fetchall()
+        bots: List[BotConfig] = []
+        for r in rows:
+            bots.append(
+                BotConfig(
+                    id=r["bot_id"],
+                    cycle=r["cycle_id"],
+                    name=r["name"],
+                    mutations=json.loads(r["mutations_json"]) if r["mutations_json"] else {},
+                    seed_parent=r["seed_parent"],
+                )
+            )
+        return bots
+
+    def get_cycle_winner(self, cycle_id: int) -> Optional[int]:
+        """Return winner bot id for a given cycle if stored."""
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT winner_bot_id FROM cycles WHERE cycle_id = ?", (cycle_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        return row["winner_bot_id"] if row["winner_bot_id"] is not None else None
+
+    # ------------------------------------------------------------------
+    # Bot stats
     def save_bot_stats(self, stats: BotStats) -> None:
-        self._bot_stats[stats.bot_id] = stats
+        with self._lock, self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO bot_stats (
+                    bot_id, cycle_id, orders, pnl, pnl_pct, runtime_s, wins, losses, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                ON CONFLICT(bot_id, cycle_id) DO UPDATE SET
+                    orders=excluded.orders,
+                    pnl=excluded.pnl,
+                    pnl_pct=excluded.pnl_pct,
+                    runtime_s=excluded.runtime_s,
+                    wins=excluded.wins,
+                    losses=excluded.losses,
+                    updated_at=CURRENT_TIMESTAMP
+                """,
+                (
+                    stats.bot_id,
+                    stats.cycle,
+                    stats.orders,
+                    stats.pnl,
+                    stats.pnl_pct,
+                    stats.runtime_s,
+                    stats.wins,
+                    stats.losses,
+                ),
+            )
 
-    def get_bot_stats(self, bot_id: int) -> Optional[BotStats]:
-        return self._bot_stats.get(bot_id)
+    def get_bot_stats(self, bot_id: int, cycle: Optional[int] = None) -> Optional[BotStats]:
+        query = (
+            "SELECT bot_id, cycle_id, orders, pnl, pnl_pct, runtime_s, wins, losses "
+            "FROM bot_stats WHERE bot_id = ?"
+        )
+        params: List[Any] = [bot_id]
+        if cycle is not None:
+            query += " AND cycle_id = ?"
+            params.append(cycle)
+        query += " ORDER BY cycle_id DESC LIMIT 1"
+        with self._lock:
+            row = self.conn.execute(query, params).fetchone()
+        if row is None:
+            return None
+        return BotStats(
+            bot_id=row["bot_id"],
+            cycle=row["cycle_id"],
+            orders=row["orders"],
+            pnl=row["pnl"],
+            pnl_pct=row["pnl_pct"],
+            runtime_s=row["runtime_s"],
+            wins=row["wins"],
+            losses=row["losses"],
+        )
 
-    def iter_stats(self) -> List[BotStats]:
-        return list(self._bot_stats.values())
+    def iter_stats(self, cycle: Optional[int] = None) -> List[BotStats]:
+        query = "SELECT bot_id, cycle_id, orders, pnl, pnl_pct, runtime_s, wins, losses FROM bot_stats"
+        params: List[Any] = []
+        if cycle is not None:
+            query += " WHERE cycle_id = ?"
+            params.append(cycle)
+        with self._lock:
+            rows = self.conn.execute(query, params).fetchall()
+        return [
+            BotStats(
+                bot_id=r["bot_id"],
+                cycle=r["cycle_id"],
+                orders=r["orders"],
+                pnl=r["pnl"],
+                pnl_pct=r["pnl_pct"],
+                runtime_s=r["runtime_s"],
+                wins=r["wins"],
+                losses=r["losses"],
+            )
+            for r in rows
+        ]
 
-    # -- Ciclos --
+    # ------------------------------------------------------------------
+    # Orders
+    _ORDER_COLS = [
+        "order_id",
+        "bot_id",
+        "cycle_id",
+        "symbol",
+        "side",
+        "qty",
+        "price",
+        "resulting_fill_price",
+        "fee_asset",
+        "fee_amount",
+        "ts",
+        "status",
+        "pnl",
+        "pnl_pct",
+        "notes",
+        "raw_json",
+        "expected_profit_ticks",
+        "actual_profit_ticks",
+        "spread_ticks",
+        "imbalance_pct",
+        "top3_depth",
+        "book_hash",
+        "latency_ms",
+        "cancel_replace_count",
+        "time_in_force",
+        "hold_time_s",
+    ]
+
+    def save_order(self, order: Dict[str, Any]) -> None:
+        values = [order.get(col) for col in self._ORDER_COLS]
+        placeholders = ",".join(["?"] * len(self._ORDER_COLS))
+        cols = ",".join(self._ORDER_COLS)
+        with self._lock, self.conn:
+            self.conn.execute(
+                f"INSERT OR REPLACE INTO orders ({cols}) VALUES ({placeholders})",
+                values,
+            )
+
+    def iter_orders(
+        self, cycle: Optional[int] = None, bot_id: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        query = f"SELECT {', '.join(self._ORDER_COLS)} FROM orders"
+        params: List[Any] = []
+        clauses: List[str] = []
+        if cycle is not None:
+            clauses.append("cycle_id = ?")
+            params.append(cycle)
+        if bot_id is not None:
+            clauses.append("bot_id = ?")
+            params.append(bot_id)
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+        with self._lock:
+            rows = self.conn.execute(query, params).fetchall()
+        return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Cycles
     def save_cycle_summary(self, cycle: int, summary: Dict[str, Any]) -> None:
-        self._cycle_summary[cycle] = summary
+        started_at = summary.get("started_at")
+        finished_at = summary.get("finished_at")
+        winner_bot_id = summary.get("winner_bot_id")
+        winner_reason = summary.get("winner_reason")
+        with self._lock, self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO cycles (cycle_id, started_at, finished_at, winner_bot_id, winner_reason)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(cycle_id) DO UPDATE SET
+                    started_at=COALESCE(excluded.started_at, cycles.started_at),
+                    finished_at=COALESCE(excluded.finished_at, cycles.finished_at),
+                    winner_bot_id=excluded.winner_bot_id,
+                    winner_reason=excluded.winner_reason
+                """,
+                (cycle, started_at, finished_at, winner_bot_id, winner_reason),
+            )
 
     def get_cycle_summary(self, cycle: int) -> Optional[Dict[str, Any]]:
-        return self._cycle_summary.get(cycle)
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT cycle_id, started_at, finished_at, winner_bot_id, winner_reason FROM cycles WHERE cycle_id = ?",
+                (cycle,),
+            ).fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        with self._lock:
+            self.conn.close()

--- a/orchestrator/supervisor.py
+++ b/orchestrator/supervisor.py
@@ -2,26 +2,38 @@
 from __future__ import annotations
 
 import asyncio
+import csv
+import json
+import hashlib
 import random
 import threading
 import time
 from datetime import datetime
+from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 
+from llm import LLMClient
+
 from .models import BotConfig, BotStats, SupervisorEvent
-from .storage import InMemoryStorage
+from .storage import SQLiteStorage
+from state.app_state import AppState
 
 
 class Supervisor:
     """Orquesta ciclos de bots ejecutados en paralelo."""
 
-    def __init__(self, storage: Optional[InMemoryStorage] = None) -> None:
-        self.storage = storage or InMemoryStorage()
+    def __init__(
+        self,
+        storage: Optional[SQLiteStorage] = None,
+        app_state: Optional[AppState] = None,
+    ) -> None:
+        self.storage = storage or SQLiteStorage()
+        self.state = app_state or AppState.load()
         self._callbacks: List[Callable[[SupervisorEvent], None]] = []
-        self._running = False
+        self.mass_tests_enabled = False
         self._thread: Optional[threading.Thread] = None
         self._num_bots = 10
-        self._next_bot_id = 1
+        self._next_bot_id = self.state.next_bot_id
         self._current_generation: List[BotConfig] = []
 
     # ------------------------------------------------------------------
@@ -58,10 +70,10 @@ class Supervisor:
     # ------------------------------------------------------------------
     def start_mass_tests(self, num_bots: int = 10) -> None:
         """Inicia el ciclo continuo de testeos en un hilo aparte."""
-        if self._running:
+        if self.mass_tests_enabled:
             return
         self._num_bots = num_bots
-        self._running = True
+        self.mass_tests_enabled = True
         # Generación inicial vacía -> se creará en el primer ciclo
         self._current_generation = []
         self._thread = threading.Thread(target=self._loop, daemon=True)
@@ -69,45 +81,105 @@ class Supervisor:
 
     def stop_mass_tests(self) -> None:
         """Detiene los ciclos de testeos."""
-        self._running = False
+        self.mass_tests_enabled = False
 
     # ------------------------------------------------------------------
     def _loop(self) -> None:
-        cycle = 1
-        while self._running:
+        while self.mass_tests_enabled:
+            cycle = self.state.current_cycle + 1
             asyncio.run(self.run_cycle(cycle))
             stats = self.gather_results(cycle)
-            winner_id, winner_cfg = self.pick_winner(cycle)
+            cycle_summary = self._compose_cycle_summary(cycle, stats)
+            client = LLMClient()
+            try:
+                decision = client.analyze_cycle_and_pick_winner(cycle_summary)
+                winner_id = int(decision.get("winner_bot_id", -1))
+                winner_reason = str(decision.get("reason", ""))
+                winner_cfg = self.storage.get_bot(winner_id)
+                if winner_cfg is None:
+                    raise ValueError("winner cfg not found")
+            except Exception:
+                winner_id, winner_cfg = self.pick_winner(cycle)
+                winner_reason = "max_pnl"
+            total_pnl = sum(s.pnl for s in stats)
+            cycle_summary["winner_bot_id"] = winner_id
+            cycle_summary["winner_reason"] = winner_reason
             self._emit(
                 "INFO",
                 "cycle",
                 cycle,
                 None,
                 "cycle_winner",
-                {"winner_id": winner_id},
+                {"winner_id": winner_id, "reason": winner_reason},
+            )
+            self._emit("INFO", "bot", cycle, winner_id, "bot_winner", {"reason": winner_reason})
+            finished_at = datetime.utcnow().isoformat()
+            self.storage.save_cycle_summary(
+                cycle,
+                {
+                    "finished_at": finished_at,
+                    "winner_bot_id": winner_id,
+                    "winner_reason": winner_reason,
+                },
+            )
+            self.export_report(cycle, cycle_summary)
+            self._emit(
+                "INFO",
+                "cycle",
+                cycle,
+                None,
+                "cycle_finished",
+                {
+                    "total_pnl": total_pnl,
+                    "winner_id": winner_id,
+                    "winner_reason": winner_reason,
+                    "finished_at": finished_at,
+                },
             )
             self.spawn_next_generation_from_winner(winner_cfg)
-            cycle += 1
-        self._running = False
+            self.state.current_cycle = cycle
+            self.state.next_bot_id = self._next_bot_id
+            self.state.save()
+        self.mass_tests_enabled = False
 
     # ------------------------------------------------------------------
     async def run_cycle(self, cycle: int) -> None:
         """Ejecuta un ciclo completo simulando bots."""
+        # Persist start of cycle
+        self.storage.save_cycle_summary(cycle, {"started_at": datetime.utcnow().isoformat()})
         # Generar bots si es la primera vez
         if not self._current_generation:
-            self._current_generation = [
-                BotConfig(
+            variations: List[Dict[str, object]] = []
+            client = LLMClient()
+            if cycle == 1:
+                try:
+                    variations = client.generate_initial_variations("")
+                except Exception:
+                    variations = []
+            else:
+                # generar a partir del ganador del ciclo previo
+                try:
+                    prev_winner_id = self.storage.get_cycle_winner(cycle - 1)
+                    winner_cfg = self.storage.get_bot(prev_winner_id) if prev_winner_id else None
+                    history = [self._fingerprint(b.mutations) for b in self.storage.iter_bots()]
+                    if winner_cfg:
+                        variations = client.new_generation_from_winner(winner_cfg.mutations, history)
+                except Exception:
+                    variations = []
+
+            self._current_generation = []
+            for i in range(self._num_bots):
+                var = variations[i] if i < len(variations) else {"name": f"Bot-{self._next_bot_id + i}", "mutations": {}}
+                cfg = BotConfig(
                     id=self._next_bot_id + i,
                     cycle=cycle,
-                    name=f"Bot-{self._next_bot_id + i}",
-                    mutations={},
+                    name=str(var.get("name", f"Bot-{self._next_bot_id + i}")),
+                    mutations=var.get("mutations", {}),
                     seed_parent=None,
                 )
-                for i in range(self._num_bots)
-            ]
-            self._next_bot_id += self._num_bots
-            for cfg in self._current_generation:
                 self.storage.save_bot(cfg)
+                self._current_generation.append(cfg)
+            self._next_bot_id += self._num_bots
         else:
             # actualizar ciclo en configs existentes
             for cfg in self._current_generation:
@@ -153,6 +225,43 @@ class Supervisor:
         """Obtiene las estadísticas de un ciclo."""
         return [s for s in self.storage.iter_stats() if s.cycle == cycle]
 
+    def _compose_cycle_summary(self, cycle: int, stats: List[BotStats]) -> Dict[str, object]:
+        """Construye el payload que se envía al LLM para análisis."""
+
+        summary: Dict[str, object] = {"cycle": cycle, "bots": []}
+        for s in stats:
+            cfg = self.storage.get_bot(s.bot_id)
+            orders = self.storage.iter_orders(cycle, s.bot_id)
+            pairs: Dict[str, float] = {}
+            for o in orders:
+                sym = o.get("symbol")
+                pnl = float(o.get("pnl") or 0)
+                if sym:
+                    pairs[sym] = pairs.get(sym, 0.0) + pnl
+            top3 = [
+                {"symbol": sym, "pnl": pnl}
+                for sym, pnl in sorted(pairs.items(), key=lambda x: x[1], reverse=True)[:3]
+            ]
+            summary["bots"].append(
+                {
+                    "bot_id": s.bot_id,
+                    "mutations": cfg.mutations if cfg else {},
+                    "stats": {
+                        "orders": s.orders,
+                        "pnl": s.pnl,
+                        "pnl_pct": s.pnl_pct,
+                        "win_rate": s.wins / s.orders if s.orders else 0.0,
+                        "avg_hold_s": 0.0,
+                        "avg_slippage_ticks": 0.0,
+                        "timeouts": 0,
+                        "cancel_replace_count": 0,
+                    },
+                    "top3_pairs": top3,
+                    "hourly_dist": {},
+                }
+            )
+        return summary
+
     def pick_winner(self, cycle: int) -> Tuple[int, BotConfig]:
         """Selecciona el bot con mayor PNL."""
         stats = self.gather_results(cycle)
@@ -165,20 +274,67 @@ class Supervisor:
         return winner.bot_id, cfg
 
     def spawn_next_generation_from_winner(self, winner_config: BotConfig) -> List[BotConfig]:
-        """Genera nuevas configuraciones basadas en el ganador."""
+        """Genera nuevas configuraciones basadas en el ganador previo."""
+
         next_cycle = winner_config.cycle + 1
+        client = LLMClient()
+        # fingerprints históricos para evitar duplicados
+        history = [self._fingerprint(b.mutations) for b in self.storage.iter_bots()]
+        try:
+            variations = client.new_generation_from_winner(winner_config.mutations, history)
+        except Exception:
+            variations = []
+
         new_generation: List[BotConfig] = []
-        for _ in range(self._num_bots):
+        seen = set(history)
+        for i in range(self._num_bots):
+            var = variations[i] if i < len(variations) else {"name": f"Bot-{self._next_bot_id}", "mutations": {}}
+            muts = var.get("mutations", {})
+            fp = self._fingerprint(muts)
+            if fp in seen:
+                # evitar duplicado generando uno aleatorio simple
+                muts = {"seed": random.random()}
+                fp = self._fingerprint(muts)
+            seen.add(fp)
             bot_id = self._next_bot_id
             self._next_bot_id += 1
             cfg = BotConfig(
                 id=bot_id,
                 cycle=next_cycle,
-                name=f"Bot-{bot_id}",
-                mutations={"mut": random.random()},
+                name=str(var.get("name", f"Bot-{bot_id}")),
+                mutations=muts,
                 seed_parent=winner_config.name,
             )
             self.storage.save_bot(cfg)
             new_generation.append(cfg)
         self._current_generation = new_generation
         return new_generation
+
+    # ------------------------------------------------------------------
+    def _fingerprint(self, mutations: Dict[str, object]) -> str:
+        """Crea un hash de los parámetros para evitar duplicados."""
+        return hashlib.sha256(json.dumps(mutations, sort_keys=True).encode()).hexdigest()
+
+    # ------------------------------------------------------------------
+    def export_report(self, cycle: int, summary: Dict[str, object]) -> None:
+        """Exporta un resumen del ciclo en JSON y CSV."""
+        reports = Path("reports")
+        reports.mkdir(exist_ok=True)
+        json_path = reports / f"cycle_{cycle}.json"
+        with json_path.open("w", encoding="utf-8") as fh:
+            json.dump(summary, fh, ensure_ascii=False, indent=2)
+        csv_rows = []
+        for bot in summary.get("bots", []):
+            row = {
+                "bot_id": bot.get("bot_id"),
+                "pnl": bot.get("stats", {}).get("pnl"),
+                "pnl_pct": bot.get("stats", {}).get("pnl_pct"),
+                "orders": bot.get("stats", {}).get("orders"),
+            }
+            csv_rows.append(row)
+        if csv_rows:
+            csv_path = reports / f"cycle_{cycle}.csv"
+            with csv_path.open("w", newline="", encoding="utf-8") as fh:
+                writer = csv.DictWriter(fh, fieldnames=list(csv_rows[0].keys()))
+                writer.writeheader()
+                writer.writerows(csv_rows)

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,69 @@
+CREATE TABLE IF NOT EXISTS cycles (
+    cycle_id INTEGER PRIMARY KEY,
+    started_at TEXT,
+    finished_at TEXT,
+    winner_bot_id INTEGER,
+    winner_reason TEXT
+);
+
+CREATE TABLE IF NOT EXISTS bots (
+    bot_id INTEGER PRIMARY KEY,
+    cycle_id INTEGER,
+    name TEXT,
+    seed_parent TEXT,
+    mutations_json TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS bot_stats (
+    bot_id INTEGER,
+    cycle_id INTEGER,
+    orders INTEGER,
+    pnl REAL,
+    pnl_pct REAL,
+    runtime_s INTEGER,
+    wins INTEGER,
+    losses INTEGER,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (bot_id, cycle_id)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    order_id TEXT PRIMARY KEY,
+    bot_id INTEGER,
+    cycle_id INTEGER,
+    symbol TEXT,
+    side TEXT,
+    qty REAL,
+    price REAL,
+    resulting_fill_price REAL,
+    fee_asset TEXT,
+    fee_amount REAL,
+    ts TEXT,
+    status TEXT,
+    pnl REAL,
+    pnl_pct REAL,
+    notes TEXT,
+    raw_json TEXT,
+    expected_profit_ticks INTEGER,
+    actual_profit_ticks INTEGER,
+    spread_ticks REAL,
+    imbalance_pct REAL,
+    top3_depth TEXT,
+    book_hash TEXT,
+    latency_ms INTEGER,
+    cancel_replace_count INTEGER,
+    time_in_force TEXT,
+    hold_time_s REAL
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT,
+    level TEXT,
+    scope TEXT,
+    bot_id INTEGER,
+    cycle_id INTEGER,
+    message TEXT,
+    payload_json TEXT
+);


### PR DESCRIPTION
## Summary
- add BotRunner to execute strategy mutations asynchronously
- introduce parametrizable base strategy and mutation mapping utilities
- expose helper to instantiate engine with hooks; wire order callbacks in legacy engine
- create LLM client with initial-variation prompt and integrate into supervisor
- persist tournament data, orders and events in SQLite
- make SQLite storage thread-safe for supervisor thread
- analyze finished cycles via LLM to pick a winner and record the reason
- remove leftover merge markers from LLM client
- generate new strategy variations from the previous cycle winner while avoiding historical duplicates
- wire supervisor events into the UI and allow loading the winning bot into SIM mode
- implement parameter dataclasses and profit-aware pair selection for the base strategy
- run cycles continuously after "Iniciar Testeos" and export JSON/CSV reports with persistent bot IDs
- persist detailed order metrics for consistent post-cycle summaries

## Testing
- `python -m py_compile orchestrator/runner.py orchestrator/storage.py`
- `python - <<'PY'
import os, asyncio, json, time
from orchestrator.storage import SQLiteStorage
from orchestrator.models import BotConfig
from orchestrator.runner import BotRunner
from engine.strategy_base import StrategyBase

class DummyExchange:
    async def get_markets(self):
        return {"ETHBTC": {"price_increment": 1e-8, "maker":0, "taker":0}}
    async def get_ticker(self, symbol):
        return {"last":0.001, "base_volume":10}
    async def get_order_book(self, symbol):
        return {"bids": [[0.001, 2]], "asks": [[0.0011, 1]]}
    async def get_market(self, symbol):
        return {"price_increment":1e-8}
    async def create_limit_buy_order(self, symbol, amount, price):
        return {"id": f"b{time.time()}", "symbol": symbol, "amount": amount, "price": price}
    async def create_limit_sell_order(self, symbol, amount, price):
        return {"id": f"s{time.time()}", "symbol": symbol, "amount": amount, "price": price}

async def main():
    try:
        os.remove('titanbot.db')
    except FileNotFoundError:
        pass
    storage = SQLiteStorage()
    exchange = DummyExchange()
    strategy = StrategyBase(exchange)
    cfg = BotConfig(id=1, cycle=1, name='bot', mutations={"commission_buffer_ticks":0}, seed_parent=None)
    runner = BotRunner(cfg, {"max_orders": 2, "max_scans": 1}, exchange, strategy, storage)
    stats = await runner.run()
    rows = storage.iter_orders()
    print('orders_logged', len(rows))
    if rows:
        first = rows[0]
        print('sample_order_keys', sorted(first.keys()))
        print('sample_order', first)
    storage.close()

asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a0ee92e0c4832886b71eefd9285a23