### PR TITLE
feat: add global llm prompt header and log decisions

### DIFF
--- a/components/testeos_frame.py
+++ b/components/testeos_frame.py
@@ -92,7 +92,12 @@ class TesteosFrame(ttk.Frame):
             self.tree.delete(item)
 
     def update_bot_row(self, stats: Dict[str, Any]) -> None:
-        """Inserta o actualiza una fila con estadísticas de un bot."""
+        """Inserta o actualiza una fila con estadísticas de un bot.
+
+        Puede llamarse varias veces mientras el bot está en ejecución para
+        reflejar su progreso (órdenes y PnL) o una vez finalizado con los
+        valores definitivos.
+        """
         bot_id = int(stats.get("bot_id"))
         cycle = stats.get("cycle", "")
         orders = stats.get("orders", 0)

--- a/llm/client.py
+++ b/llm/client.py
@@ -10,6 +10,7 @@ from .prompts import (
     PROMPT_INICIAL_VARIACIONES,
     PROMPT_ANALISIS_CICLO,
     PROMPT_NUEVA_GENERACION_DESDE_GANADOR,
+    PROMPT_P0,
 )
 
 class LLMClient:
@@ -38,6 +39,7 @@ class LLMClient:
             model=self.model,
             temperature=0.2,
             messages=[
+                {"role": "system", "content": PROMPT_P0},
                 {"role": "system", "content": PROMPT_INICIAL_VARIACIONES},
                 {"role": "user", "content": trading_spec_text},
             ],
@@ -180,6 +182,7 @@ class LLMClient:
                     model=self.model,
                     temperature=0.2,
                     messages=[
+                        {"role": "system", "content": PROMPT_P0},
                         {"role": "system", "content": prompt},
                         {
                             "role": "user",
@@ -238,6 +241,7 @@ class LLMClient:
                     model=self.model,
                     temperature=0,
                     messages=[
+                        {"role": "system", "content": PROMPT_P0},
                         {"role": "system", "content": PROMPT_ANALISIS_CICLO},
                         {"role": "user", "content": json.dumps(cycle_summary)},
                     ],

--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -1,5 +1,13 @@
 """Prompts estáticos usados por el cliente LLM."""
 
+# Cabecera global que se antepone a todos los prompts enviados al LLM.
+PROMPT_P0 = (
+    "Proyecto TITAN-BOT. Módulo 'Testeos Masivos' con 10 bots concurrentes. "
+    "Usa datos de mercado en tiempo real (snapshot REST + diffs WS), simula fills "
+    "contra el order book, respeta rate limits y muestra logs del LLM en la UI. "
+    "Código claro, modular, testeable y con manejo de errores."
+)
+
 PROMPT_INICIAL_VARIACIONES = """
 SISTEMA: Eres experto en microestructura y market-making spot en Binance (pares XXXBTC). Tarea: generar 10 variaciones de una estrategia base que compra en nivel con acumulación de bids y vende +1 tick, con filtros: beneficio > comisiones (compra+venta), volumen ≥ 5 BTC/24h y monitoreo del libro para mover/cancelar órdenes ante cambios.
 REQUISITOS:

--- a/llm_client.py
+++ b/llm_client.py
@@ -2,6 +2,8 @@
 import time, uuid, os
 from typing import Dict, List, Any
 
+from llm.prompts import PROMPT_P0
+
 class LLMClient:
     """
     Cliente LLM:
@@ -58,7 +60,10 @@ class LLMClient:
             try:
                 resp = self._openai.chat.completions.create(
                     model=self.model,
-                    messages=[{"role": "user", "content": message}],
+                    messages=[
+                        {"role": "system", "content": PROMPT_P0},
+                        {"role": "user", "content": message},
+                    ],
                     temperature=self.temp_op,
                     timeout=20,
                 )
@@ -79,7 +84,10 @@ class LLMClient:
             try:
                 resp = self._openai.chat.completions.create(
                     model=self.model,
-                    messages=[{"role": "user", "content": message}],
+                    messages=[
+                        {"role": "system", "content": PROMPT_P0},
+                        {"role": "user", "content": message},
+                    ],
                     temperature=self.temp_ana,
                     timeout=20,
                 )
@@ -109,18 +117,22 @@ class LLMClient:
             "Responde en JSON con el campo 'actions'."
         )
 
-        content = {"role":"system","content":sys_msg}
+        content = {"role": "system", "content": sys_msg}
         user_content = {
             "role": "user",
             "content": f"Snapshot:\n{snapshot}\n\n"
                        "Devuelve JSON: {'ts':<ms>,'actions':[{'id':str,'symbol':str,'type':str,"
                        "'price':float,'qty_usd':float,'tif':str,'max_slippage_ticks':int,"
-                       "'reason':str,'confidence':float}]} (usa solo campos necesarios)."
+                       "'reason':str,'confidence':float}]} (usa solo campos necesarios).",
         }
         resp = client.chat.completions.create(
             model=self.model,
             temperature=self.temp_op,
-            messages=[content, user_content],
+            messages=[
+                {"role": "system", "content": PROMPT_P0},
+                content,
+                user_content,
+            ],
             timeout=20,
         )
         txt = resp.choices[0].message.content or "{}"

--- a/ui_app.py
+++ b/ui_app.py
@@ -7,7 +7,8 @@ from typing import Dict, Any, List
 
 from config import UIColors, Defaults, AppState as CoreAppState
 from engine import Engine, load_sim_config
-from llm_client import LLMClient
+from llm_client import LLMClient as EngineLLMClient
+from llm import LLMClient as MassLLMClient
 from components.testeos_frame import TesteosFrame
 from state.app_state import AppState as MassTestState
 from orchestrator.supervisor import Supervisor
@@ -92,7 +93,9 @@ class App(tb.Window):
         self._snapshot: Dict[str, Any] = {}
         self._log_queue: "queue.Queue[str]" = queue.Queue()
         self._event_queue: "queue.Queue" = queue.Queue()
-        self._supervisor = Supervisor(app_state=self.mass_state)
+        self._supervisor = Supervisor(
+            app_state=self.mass_state, llm_client=MassLLMClient()
+        )
         self._supervisor.stream_events(lambda ev: self._event_queue.put(ev))
         self._engine_sim: Engine | None = None
         self._engine_live: Engine | None = None
@@ -412,7 +415,9 @@ class App(tb.Window):
         elif self._engine_live:
             llm = self._engine_live.llm
         else:
-            llm = LLMClient(model=self.var_llm_model.get(), api_key=self.var_oai_key.get())
+            llm = EngineLLMClient(
+                model=self.var_llm_model.get(), api_key=self.var_oai_key.get()
+            )
         resp = ""
         try:
             resp = llm.ask(query)
@@ -528,6 +533,16 @@ class App(tb.Window):
                             "status": "RUNNING",
                         }
                     )
+                elif ev.message == "bot_progress" and ev.payload:
+                    self.testeos_frame.update_bot_row(
+                        {
+                            "bot_id": ev.bot_id,
+                            "cycle": ev.cycle,
+                            "orders": ev.payload.get("orders", 0),
+                            "pnl": ev.payload.get("pnl", 0.0),
+                            "status": "RUNNING",
+                        }
+                    )
                 elif ev.message == "bot_finished" and ev.payload:
                     stats = ev.payload.get("stats", {})
                     stats.update({"bot_id": ev.bot_id, "cycle": ev.cycle, "status": "DONE"})
@@ -542,6 +557,13 @@ class App(tb.Window):
                     info = ev.payload
                     info["cycle"] = ev.cycle
                     self.testeos_frame.add_cycle_history(info)
+                elif ev.scope == "llm":
+                    if ev.message == "llm_request" and ev.payload:
+                        self.log_append(f"[LLM] request {json.dumps(ev.payload)}")
+                    elif ev.message == "llm_response" and ev.payload:
+                        self.log_append(f"[LLM] response {json.dumps(ev.payload)}")
+                    elif ev.message == "llm_error" and ev.payload:
+                        self.log_append(f"[LLM] error {ev.payload.get('error')}")
 
         except queue.Empty:
             pass


### PR DESCRIPTION
## Summary
- prepend global project header to every LLM call
- stream LLM request/response events so UI logs them

## Testing
- `python -m py_compile llm/prompts.py llm/client.py llm_client.py orchestrator/supervisor.py ui_app.py components/testeos_frame.py`
- `python - <<'PY'
import time
from orchestrator.supervisor import Supervisor
from llm import LLMClient

logs = []

sup = Supervisor(llm_client=LLMClient())
sup.stream_events(lambda ev: logs.append((ev.scope, ev.message)))
sup.start_mass_tests()
# Wait for one cycle
time.sleep(8)
sup.stop_mass_tests()
# allow thread to finish
time.sleep(2)
print('cycles', sup.state.current_cycle)
print('llm_events', [l for l in logs if l[0]=="llm"][:4])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a124ee0d148328b5b70d9d60eb7632