### PR TITLE
feat: centralize market data hub and expose tuning params

### DIFF
--- a/components/testeos_frame.py
+++ b/components/testeos_frame.py
@@ -13,7 +13,7 @@ class TesteosFrame(ttk.Frame):
     def __init__(
         self,
         parent: ttk.Widget,
-        on_toggle: Callable[[bool], None],
+        on_toggle: Callable[[bool, Dict[str, Any]], None],
         on_load_winner_for_sim: Callable[[], None],
     ) -> None:
         super().__init__(parent, padding=10)
@@ -32,13 +32,44 @@ class TesteosFrame(ttk.Frame):
         self.rowconfigure(4, weight=1)
         self.rowconfigure(5, weight=1)
 
+        self.var_num_bots = tk.IntVar(value=10)
+        self.var_max_depth = tk.IntVar(value=20)
+        self.var_depth_speed = tk.StringVar(value="100ms")
+        self.var_mode = tk.StringVar(value="SIM")
+
+        top = ttk.Frame(self)
+        top.grid(row=0, column=0, sticky="w")
         self.btn_toggle = ttk.Button(
-            self,
+            top,
             text="Iniciar Testeos",
             bootstyle=SUCCESS,
             command=self._toggle,
         )
-        self.btn_toggle.grid(row=0, column=0, sticky="w")
+        self.btn_toggle.grid(row=0, column=0, padx=(0, 8))
+        ttk.Label(top, text="Bots:").grid(row=0, column=1, padx=(0, 2))
+        ttk.Spinbox(top, from_=1, to=50, width=5, textvariable=self.var_num_bots).grid(
+            row=0, column=2, padx=(0, 8)
+        )
+        ttk.Label(top, text="MAX_DEPTH:").grid(row=0, column=3, padx=(0, 2))
+        ttk.Spinbox(top, from_=1, to=50, width=5, textvariable=self.var_max_depth).grid(
+            row=0, column=4, padx=(0, 8)
+        )
+        ttk.Label(top, text="Speed:").grid(row=0, column=5, padx=(0, 2))
+        ttk.Combobox(
+            top,
+            values=["100ms", "1000ms"],
+            width=7,
+            state="readonly",
+            textvariable=self.var_depth_speed,
+        ).grid(row=0, column=6, padx=(0, 8))
+        ttk.Label(top, text="Modo:").grid(row=0, column=7, padx=(0, 2))
+        ttk.Combobox(
+            top,
+            values=["SIM", "LIVE"],
+            width=5,
+            state="readonly",
+            textvariable=self.var_mode,
+        ).grid(row=0, column=8)
 
         cols = ("bot_id", "cycle", "orders", "pnl", "status", "winner")
         self.tree = ttk.Treeview(self, columns=cols, show="headings", height=10)
@@ -110,7 +141,7 @@ class TesteosFrame(ttk.Frame):
         else:
             self.btn_toggle.configure(text="Iniciar Testeos", bootstyle=SUCCESS)
         try:
-            self._on_toggle(self._running)
+            self._on_toggle(self._running, self.get_params())
         except Exception:
             pass
 
@@ -201,3 +232,12 @@ class TesteosFrame(ttk.Frame):
         self.txt_logs.configure(state="normal")
         self.txt_logs.delete("1.0", "end")
         self.txt_logs.configure(state="disabled")
+
+    def get_params(self) -> Dict[str, Any]:
+        """Retorna la configuración actual de los controles."""
+        return {
+            "num_bots": self.var_num_bots.get(),
+            "max_depth_symbols": self.var_max_depth.get(),
+            "depth_speed": self.var_depth_speed.get(),
+            "mode": self.var_mode.get(),
+        }

--- a/orchestrator/supervisor.py
+++ b/orchestrator/supervisor.py
@@ -16,7 +16,23 @@ from llm import LLMClient
 from .models import BotConfig, BotStats, SupervisorEvent
 from .storage import SQLiteStorage
 from state.app_state import AppState
-from exchange_utils.orderbook_service import market_data_hub
+import exchange_utils.orderbook_service as ob_service
+import exchange_utils.exchange_meta as exchange_meta_mod
+from exchange_utils.orderbook_service import MarketDataHub
+from exchange_utils.exchange_meta import ExchangeMeta
+
+POPULAR_SYMBOLS = [
+    "BTCUSDT",
+    "ETHUSDT",
+    "BNBUSDT",
+    "XRPUSDT",
+    "SOLUSDT",
+    "ADAUSDT",
+    "DOGEUSDT",
+    "MATICUSDT",
+    "LTCUSDT",
+    "TRXUSDT",
+]
 
 class Supervisor:
     """Orquesta ciclos de bots ejecutados en paralelo."""
@@ -47,9 +63,12 @@ class Supervisor:
         self._callbacks: List[Callable[[SupervisorEvent], None]] = []
         self.mass_tests_enabled = False
         self._thread: Optional[threading.Thread] = None
-        self._num_bots = 10
+        self._num_bots = self.state.bots_per_cycle
         self._next_bot_id = self.state.next_bot_id
         self._current_generation: List[BotConfig] = []
+        self.hub: Optional[MarketDataHub] = None
+        self.exchange_meta: Optional[ExchangeMeta] = None
+        self._last_symbols: set[str] = set()
 
     # ------------------------------------------------------------------
     # Streaming de eventos
@@ -88,6 +107,17 @@ class Supervisor:
         if self.mass_tests_enabled:
             return
         self._num_bots = num_bots
+        if not self.hub:
+            try:
+                ob_service.market_data_hub.close()
+            except Exception:
+                pass
+            self.hub = ob_service.MarketDataHub(self.state.max_depth_symbols)
+            ob_service.market_data_hub = self.hub
+            self.exchange_meta = exchange_meta_mod.ExchangeMeta()
+            exchange_meta_mod.exchange_meta = self.exchange_meta
+        else:
+            self.hub._sub_mgr.max_depth = self.state.max_depth_symbols
         self.mass_tests_enabled = True
         # Generación inicial vacía -> se creará en el primer ciclo
         self._current_generation = []
@@ -97,6 +127,12 @@ class Supervisor:
     def stop_mass_tests(self) -> None:
         """Detiene los ciclos de testeos."""
         self.mass_tests_enabled = False
+        if self.hub:
+            try:
+                self.hub.close()
+            except Exception:
+                pass
+            self.hub = None
 
     # ------------------------------------------------------------------
     def _loop(self) -> None:
@@ -194,6 +230,14 @@ class Supervisor:
         """Ejecuta un ciclo completo simulando bots."""
         # Persist start of cycle
         self.storage.save_cycle_summary(cycle, {"started_at": datetime.utcnow().isoformat()})
+        if self.hub:
+            self.hub._sub_mgr.max_depth = self.state.max_depth_symbols
+            symbols = self._prepare_candidate_symbols()
+            for sym in symbols:
+                self.hub.subscribe_depth(sym, self.state.depth_speed)
+            for sym in self._last_symbols - set(symbols):
+                self.hub.unsubscribe_depth(sym)
+            self._last_symbols = set(symbols)
         # Generar bots si es la primera vez
         if not self._current_generation:
             variations: List[Dict[str, object]] = []
@@ -325,6 +369,10 @@ class Supervisor:
                 }
             )
         return summary
+
+    def _prepare_candidate_symbols(self) -> List[str]:
+        k = min(self._num_bots, len(POPULAR_SYMBOLS))
+        return random.sample(POPULAR_SYMBOLS, k)
 
     def pick_winner(self, cycle: int) -> Tuple[int, BotConfig]:
         """Selecciona el bot con mayor PNL."""

--- a/state/app_state.py
+++ b/state/app_state.py
@@ -12,6 +12,10 @@ class AppState:
     """Estado persistente para los testeos masivos."""
     current_cycle: int = 0
     next_bot_id: int = 1
+    max_depth_symbols: int = 20
+    depth_speed: str = "100ms"
+    bots_per_cycle: int = 10
+    mode: str = "SIM"
     winner_config: Optional[Dict[str, Any]] = None
     _file: str = field(init=False, repr=False)
 

--- a/ui_app.py
+++ b/ui_app.py
@@ -12,7 +12,6 @@ from llm import LLMClient as MassLLMClient
 from components.testeos_frame import TesteosFrame
 from state.app_state import AppState as MassTestState
 from orchestrator.supervisor import Supervisor
-from exchange_utils.orderbook_service import market_data_hub
 
 BADGE_SIM = "🔧SIM"
 BADGE_LIVE = "⚡LIVE"
@@ -479,11 +478,18 @@ class App(tb.Window):
             self.log_append("[TEST] Valor inválido para órdenes mínimas")
 
     # ------------------- Testeos masivos -------------------
-    def on_toggle_mass_tests(self, running: bool) -> None:
+    def on_toggle_mass_tests(self, running: bool, params: Dict[str, Any]) -> None:
         """Inicia o detiene los ciclos de testeos masivos."""
         if running:
             self.log_append("[TEST] Iniciar Testeos presionado")
-            self._supervisor.start_mass_tests()
+            st = self._supervisor.state
+            st.max_depth_symbols = int(params.get("max_depth_symbols", st.max_depth_symbols))
+            st.depth_speed = params.get("depth_speed", st.depth_speed)
+            st.bots_per_cycle = int(params.get("num_bots", st.bots_per_cycle))
+            st.mode = params.get("mode", st.mode)
+            st.save()
+            self._supervisor.mode = st.mode
+            self._supervisor.start_mass_tests(num_bots=st.bots_per_cycle)
         else:
             self.log_append("[TEST] Testeos detenidos")
             self._supervisor.stop_mass_tests()


### PR DESCRIPTION
## Summary
- centralize MarketDataHub initialization within Supervisor and manage depth subscriptions per cycle
- add UI controls for depth limits, speed, mode and bot count
- persist tuning parameters in application state and allow runtime configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1404632088328b31840fe8ee2cf1a