### PR TITLE
feat: centralize market data hub and expose tuning params

### DIFF
--- a/codex/client.py
+++ b/codex/client.py
@@ -1,0 +1,31 @@
+"""Simple Codex client used only for credential verification."""
+from __future__ import annotations
+
+import requests
+from typing import Optional
+
+
+class CodexClient:
+    """Client wrapper to check Codex API key validity."""
+
+    def __init__(self, api_key: Optional[str] = None, base_url: str = "https://api.openai.com") -> None:
+        self.api_key = api_key or ""
+        self.base_url = base_url.rstrip("/")
+
+    def check_credentials(self) -> bool:
+        """Performs a minimal authenticated request.
+
+        The endpoint is intentionally generic so this client can operate even if
+        the real Codex service is mocked in tests. Any error returns ``False``.
+        """
+        if not self.api_key:
+            return False
+        try:
+            resp = requests.get(
+                f"{self.base_url}/v1/models",
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                timeout=5,
+            )
+            return resp.status_code == 200
+        except Exception:
+            return False

--- a/components/auth_frame.py
+++ b/components/auth_frame.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+from typing import Callable, Dict
+
+
+class AuthFrame(ttk.Labelframe):
+    """Frame para ingresar claves de APIs y mostrar estado de verificación."""
+
+    def __init__(self, parent: ttk.Widget, on_confirm: Callable[[], None]) -> None:
+        super().__init__(parent, text="Claves API", padding=8)
+        self.on_confirm = on_confirm
+
+        self.columnconfigure(1, weight=1)
+
+        self.var_bin_key = tk.StringVar(value="")
+        self.var_bin_sec = tk.StringVar(value="")
+        self.var_oai_key = tk.StringVar(value="")
+        self.var_codex_key = tk.StringVar(value="")
+        self.var_use_codex = tk.BooleanVar(value=False)
+
+        ttk.Label(self, text="Binance KEY").grid(row=0, column=0, sticky="w")
+        ttk.Entry(self, textvariable=self.var_bin_key, width=28).grid(row=0, column=1, sticky="ew")
+        self.lbl_bin_status = ttk.Label(self, text="❌")
+        self.lbl_bin_status.grid(row=0, column=3, padx=4)
+
+        ttk.Label(self, text="Binance SECRET").grid(row=1, column=0, sticky="w")
+        ttk.Entry(self, textvariable=self.var_bin_sec, width=28, show="•").grid(row=1, column=1, sticky="ew")
+
+        ttk.Label(self, text="ChatGPT API Key").grid(row=2, column=0, sticky="w")
+        ttk.Entry(self, textvariable=self.var_oai_key, width=28, show="•").grid(row=2, column=1, sticky="ew")
+        self.lbl_llm_status = ttk.Label(self, text="❌")
+        self.lbl_llm_status.grid(row=2, column=3, padx=4)
+
+        ttk.Label(self, text="Codex API Key").grid(row=3, column=0, sticky="w")
+        ttk.Entry(self, textvariable=self.var_codex_key, width=28, show="•").grid(row=3, column=1, sticky="ew")
+        self.lbl_codex_status = ttk.Label(self, text="❌")
+        self.lbl_codex_status.grid(row=3, column=3, padx=4)
+
+        ttk.Checkbutton(self, text="Usar Codex", variable=self.var_use_codex).grid(row=4, column=0, sticky="w", pady=(4, 0))
+        self.btn_confirm = ttk.Button(self, text="Confirmar APIs", command=self._on_confirm)
+        self.btn_confirm.grid(row=0, column=2, rowspan=4, padx=6)
+
+    # ------------------------------------------------------------------
+    def _on_confirm(self) -> None:
+        if self.on_confirm:
+            try:
+                self.btn_confirm.configure(state="disabled")
+            except Exception:
+                pass
+            self.on_confirm()
+
+    # ------------------------------------------------------------------
+    def update_badges(self, status: Dict[str, bool]) -> None:
+        """Actualiza badges de estado para cada servicio."""
+        self.lbl_bin_status.configure(text="✅" if status.get("binance") else "❌")
+        self.lbl_llm_status.configure(text="✅" if status.get("llm") else "❌")
+        self.lbl_codex_status.configure(text="✅" if status.get("codex") else "❌")
+        try:
+            self.btn_confirm.configure(state="normal")
+        except Exception:
+            pass

--- a/components/testeos_frame.py
+++ b/components/testeos_frame.py
@@ -13,7 +13,7 @@ class TesteosFrame(ttk.Frame):
     def __init__(
         self,
         parent: ttk.Widget,
-        on_toggle: Callable[[bool], None],
+        on_toggle: Callable[[bool, Dict[str, Any]], None],
         on_load_winner_for_sim: Callable[[], None],
     ) -> None:
         super().__init__(parent, padding=10)
@@ -32,13 +32,44 @@ class TesteosFrame(ttk.Frame):
         self.rowconfigure(4, weight=1)
         self.rowconfigure(5, weight=1)
 
+        self.var_num_bots = tk.IntVar(value=10)
+        self.var_max_depth = tk.IntVar(value=20)
+        self.var_depth_speed = tk.StringVar(value="100ms")
+        self.var_mode = tk.StringVar(value="SIM")
+
+        top = ttk.Frame(self)
+        top.grid(row=0, column=0, sticky="w")
         self.btn_toggle = ttk.Button(
-            self,
+            top,
             text="Iniciar Testeos",
             bootstyle=SUCCESS,
             command=self._toggle,
         )
-        self.btn_toggle.grid(row=0, column=0, sticky="w")
+        self.btn_toggle.grid(row=0, column=0, padx=(0, 8))
+        ttk.Label(top, text="Bots:").grid(row=0, column=1, padx=(0, 2))
+        ttk.Spinbox(top, from_=1, to=50, width=5, textvariable=self.var_num_bots).grid(
+            row=0, column=2, padx=(0, 8)
+        )
+        ttk.Label(top, text="MAX_DEPTH:").grid(row=0, column=3, padx=(0, 2))
+        ttk.Spinbox(top, from_=1, to=50, width=5, textvariable=self.var_max_depth).grid(
+            row=0, column=4, padx=(0, 8)
+        )
+        ttk.Label(top, text="Speed:").grid(row=0, column=5, padx=(0, 2))
+        ttk.Combobox(
+            top,
+            values=["100ms", "1000ms"],
+            width=7,
+            state="readonly",
+            textvariable=self.var_depth_speed,
+        ).grid(row=0, column=6, padx=(0, 8))
+        ttk.Label(top, text="Modo:").grid(row=0, column=7, padx=(0, 2))
+        ttk.Combobox(
+            top,
+            values=["SIM", "LIVE"],
+            width=5,
+            state="readonly",
+            textvariable=self.var_mode,
+        ).grid(row=0, column=8)
 
         cols = ("bot_id", "cycle", "orders", "pnl", "status", "winner")
         self.tree = ttk.Treeview(self, columns=cols, show="headings", height=10)
@@ -110,7 +141,7 @@ class TesteosFrame(ttk.Frame):
         else:
             self.btn_toggle.configure(text="Iniciar Testeos", bootstyle=SUCCESS)
         try:
-            self._on_toggle(self._running)
+            self._on_toggle(self._running, self.get_params())
         except Exception:
             pass
 
@@ -201,3 +232,12 @@ class TesteosFrame(ttk.Frame):
         self.txt_logs.configure(state="normal")
         self.txt_logs.delete("1.0", "end")
         self.txt_logs.configure(state="disabled")
+
+    def get_params(self) -> Dict[str, Any]:
+        """Retorna la configuración actual de los controles."""
+        return {
+            "num_bots": self.var_num_bots.get(),
+            "max_depth_symbols": self.var_max_depth.get(),
+            "depth_speed": self.var_depth_speed.get(),
+            "mode": self.var_mode.get(),
+        }

--- a/exchange_utils/binance_check.py
+++ b/exchange_utils/binance_check.py
@@ -1,0 +1,31 @@
+import time
+import hmac
+import hashlib
+import requests
+from urllib.parse import urlencode
+
+
+def verify(api_key: str, api_secret: str, timeout: float = 5.0) -> bool:
+    """Return True if Binance API keys are valid.
+
+    Performs a signed request to ``/api/v3/account``. Any network or
+    authentication error results in ``False``. The call uses a short timeout
+    so UI callers do not block for long periods.
+    """
+    if not api_key or not api_secret:
+        return False
+    try:
+        ts = int(time.time() * 1000)
+        query = urlencode({"timestamp": ts})
+        sig = hmac.new(api_secret.encode(), query.encode(), hashlib.sha256).hexdigest()
+        params = {"timestamp": ts, "signature": sig}
+        headers = {"X-MBX-APIKEY": api_key}
+        resp = requests.get(
+            "https://api.binance.com/api/v3/account",
+            params=params,
+            headers=headers,
+            timeout=timeout,
+        )
+        return resp.status_code == 200
+    except Exception:
+        return False

--- a/llm/client.py
+++ b/llm/client.py
@@ -39,6 +39,28 @@ class LLMClient:
                 self._client = None
 
     # ------------------------------------------------------------------
+    def check_credentials(self) -> bool:
+        """Verifies that the configured API key is valid.
+
+        It performs a minimal request to the OpenAI API. Any network or
+        authentication error results in ``False`` so callers can decide how to
+        handle unavailable credentials without raising exceptions.
+        """
+        if not self.api_key:
+            return False
+        try:
+            import requests
+
+            resp = requests.get(
+                "https://api.openai.com/v1/models",
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                timeout=5,
+            )
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------
     def _log(self, tag: str, payload: Any) -> None:
         if self.on_log:
             try:

--- a/state/app_state.py
+++ b/state/app_state.py
@@ -12,7 +12,14 @@ class AppState:
     """Estado persistente para los testeos masivos."""
     current_cycle: int = 0
     next_bot_id: int = 1
+    max_depth_symbols: int = 20
+    depth_speed: str = "100ms"
+    bots_per_cycle: int = 10
+    mode: str = "SIM"
     winner_config: Optional[Dict[str, Any]] = None
+    apis_verified: Dict[str, bool] = field(
+        default_factory=lambda: {"binance": False, "llm": False, "codex": False}
+    )
     _file: str = field(init=False, repr=False)
 
     def __post_init__(self) -> None:

--- a/ui_app.py
+++ b/ui_app.py
@@ -1,4 +1,4 @@
-import threading, queue, time, json, os, copy
+import threading, queue, time, json, os, copy, asyncio
 import ttkbootstrap as tb
 from ttkbootstrap.constants import *
 from ttkbootstrap.scrolled import ScrolledText
@@ -9,10 +9,12 @@ from config import UIColors, Defaults, AppState as CoreAppState
 from engine import Engine, load_sim_config
 from llm_client import LLMClient as EngineLLMClient
 from llm import LLMClient as MassLLMClient
+from codex.client import CodexClient
 from components.testeos_frame import TesteosFrame
+from components.auth_frame import AuthFrame
 from state.app_state import AppState as MassTestState
 from orchestrator.supervisor import Supervisor
-from exchange_utils.orderbook_service import market_data_hub
+import exchange_utils.binance_check as binance_check
 
 BADGE_SIM = "🔧SIM"
 BADGE_LIVE = "⚡LIVE"
@@ -44,15 +46,21 @@ class App(tb.Window):
             key_name = str(self.var_bin_key) if hasattr(self, "var_bin_key") else None
             sec_name = str(self.var_bin_sec) if hasattr(self, "var_bin_sec") else None
             oai_name = str(self.var_oai_key) if hasattr(self, "var_oai_key") else None
+            codex_name = str(self.var_codex_key) if hasattr(self, "var_codex_key") else None
+            use_codex_name = str(self.var_use_codex) if hasattr(self, "var_use_codex") else None
             for w in self._iter_all_widgets():
                 try:
                     if w.winfo_class() in ("TEntry", "Entry"):
                         tv = w.cget("textvariable") if "textvariable" in w.keys() else ""
-                        if tv in (key_name, sec_name, oai_name):
+                        if tv in (key_name, sec_name, oai_name, codex_name):
                             w.configure(state="normal")
                     if w.winfo_class() in ("TButton", "Button"):
                         txt = w.cget("text") if "text" in w.keys() else ""
                         if "Confirmar APIs" in str(txt):
+                            w.configure(state="normal")
+                    if w.winfo_class() in ("TCheckbutton", "Checkbutton"):
+                        tv = w.cget("variable") if "variable" in w.keys() else ""
+                        if tv == use_codex_name:
                             w.configure(state="normal")
                 except Exception:
                     pass
@@ -102,6 +110,7 @@ class App(tb.Window):
         self._winner_cfg = None
 
         self._keys_file = os.path.join(os.path.dirname(__file__), ".api_keys.json")
+        self._codex_buttons: List[ttk.Button] = []
 
         self._build_ui()
         # Instanciar LLM y supervisor después de construir UI para cablear logs
@@ -109,7 +118,8 @@ class App(tb.Window):
         self._supervisor = Supervisor(app_state=self.mass_state, llm_client=llm_client)
         self._supervisor.stream_events(lambda ev: self._event_queue.put(ev))
         self._load_saved_keys()
-        self._lock_controls(True)
+        self.auth_frame.update_badges(self.mass_state.apis_verified)
+        self._apply_api_locks()
         self.after(250, self._poll_log_queue)
         self.after(250, self._poll_event_queue)
         self.after(4000, self._tick_ui_refresh)
@@ -240,21 +250,15 @@ class App(tb.Window):
             command=self._toggle_min_binance,
         ).grid(row=2, column=2, padx=6, pady=(4,0))
 
-        # API keys
-        frm_api = ttk.Labelframe(right, text="Claves API", padding=8)
-        frm_api.grid(row=2, column=0, sticky="ew", pady=6)
-        frm_api.columnconfigure(1, weight=1)
-        self.var_bin_key = tb.StringVar(value="")
-        self.var_bin_sec = tb.StringVar(value="")
-        ttk.Label(frm_api, text="Binance KEY").grid(row=0, column=0, sticky="w")
-        ttk.Entry(frm_api, textvariable=self.var_bin_key, width=28).grid(row=0, column=1, sticky="ew")
-        ttk.Label(frm_api, text="Binance SECRET").grid(row=1, column=0, sticky="w")
-        ttk.Entry(frm_api, textvariable=self.var_bin_sec, width=28, show="•").grid(row=1, column=1, sticky="ew")
-
-        self.var_oai_key = tb.StringVar(value="")
-        ttk.Label(frm_api, text="ChatGPT API Key").grid(row=2, column=0, sticky="w")
-        ttk.Entry(frm_api, textvariable=self.var_oai_key, width=28, show="•").grid(row=2, column=1, sticky="ew")
-        ttk.Button(frm_api, text="Confirmar APIs", command=self._confirm_apis).grid(row=0, column=2, rowspan=3, padx=6)
+        # API keys and verification badges
+        self.auth_frame = AuthFrame(right, self._start_confirm_apis)
+        self.auth_frame.grid(row=2, column=0, sticky="ew", pady=6)
+        # expose vars for _lock_controls helper
+        self.var_bin_key = self.auth_frame.var_bin_key
+        self.var_bin_sec = self.auth_frame.var_bin_sec
+        self.var_oai_key = self.auth_frame.var_oai_key
+        self.var_codex_key = self.auth_frame.var_codex_key
+        self.var_use_codex = self.auth_frame.var_use_codex
 
         # LLM config minimal: model + seconds + apply button
         frm_llm = ttk.Labelframe(right, text="LLM (decisor)", padding=8)
@@ -269,7 +273,9 @@ class App(tb.Window):
             width=14,
             state="readonly",
         ).grid(row=0, column=1, sticky="ew")
-        ttk.Button(frm_llm, text="Aplicar LLM", command=self._apply_llm).grid(row=0, column=2, padx=6)
+        btn_apply_llm = ttk.Button(frm_llm, text="Aplicar LLM", command=self._apply_llm)
+        btn_apply_llm.grid(row=0, column=2, padx=6)
+        self._codex_buttons.append(btn_apply_llm)
 
         # Consulta LLM
         frm_llm_manual = ttk.Labelframe(right, text="Consulta LLM", padding=8)
@@ -293,8 +299,11 @@ class App(tb.Window):
         ttk.Button(frm_info, text="Aplicar mín. órdenes", command=self._apply_min_orders).grid(
             row=2, column=0, columnspan=2, sticky="ew", pady=(4, 0)
         )
-        ttk.Button(frm_info, text="Revertir patch", command=self._revert_patch).grid(row=3, column=0, sticky="ew", pady=(4,0))
-        ttk.Button(frm_info, text="Aplicar a LIVE", command=self._apply_winner_live).grid(row=3, column=1, sticky="ew", pady=(4,0))
+        btn_revert = ttk.Button(frm_info, text="Revertir patch", command=self._revert_patch)
+        btn_revert.grid(row=3, column=0, sticky="ew", pady=(4,0))
+        btn_live = ttk.Button(frm_info, text="Aplicar a LIVE", command=self._apply_winner_live)
+        btn_live.grid(row=3, column=1, sticky="ew", pady=(4,0))
+        self._codex_buttons.extend([btn_revert, btn_live])
 
         # Log
         frm_log = ttk.Labelframe(right, text="Log", padding=8)
@@ -307,6 +316,7 @@ class App(tb.Window):
         self.var_bot_sim.trace_add("write", self._on_bot_sim)
         self.var_bot_live.trace_add("write", self._on_bot_live)
         self.var_live_confirm.trace_add("write", self._on_live_confirm)
+        self.var_use_codex.trace_add("write", lambda *_: self._apply_api_locks())
 
     # ------------------- Helpers -------------------
     def _ensure_exchange(self):
@@ -321,6 +331,7 @@ class App(tb.Window):
             self.var_bin_key.set(data.get("bin_key", ""))
             self.var_bin_sec.set(data.get("bin_sec", ""))
             self.var_oai_key.set(data.get("oai_key", ""))
+            self.var_codex_key.set(data.get("codex_key", ""))
         except Exception:
             pass
 
@@ -330,18 +341,31 @@ class App(tb.Window):
                 "bin_key": self.var_bin_key.get(),
                 "bin_sec": self.var_bin_sec.get(),
                 "oai_key": self.var_oai_key.get(),
+                "codex_key": self.var_codex_key.get(),
             }
             with open(self._keys_file, "w", encoding="utf-8") as f:
                 json.dump(data, f)
         except Exception:
             pass
 
-    def _confirm_apis(self):
-        """Confirma y guarda las claves API ingresadas en la UI."""
+    def _start_confirm_apis(self) -> None:
+        self._lock_controls(True)
+        threading.Thread(target=lambda: asyncio.run(self._confirm_apis()), daemon=True).start()
+
+    async def _confirm_apis(self) -> None:
+        """Verifica credenciales de Binance, LLM y Codex."""
         self._save_api_keys()
         key = self.var_bin_key.get().strip()
         sec = self.var_bin_sec.get().strip()
         oai = self.var_oai_key.get().strip()
+        codex_key = self.var_codex_key.get().strip()
+        llm_client = MassLLMClient(api_key=oai)
+        codex_client = CodexClient(api_key=codex_key)
+        tasks = [
+            asyncio.to_thread(binance_check.verify, key, sec),
+            asyncio.to_thread(llm_client.check_credentials),
+            asyncio.to_thread(codex_client.check_credentials),
+        ]
         try:
             self._ensure_exchange()
             self.exchange.set_api_keys(key, sec)
@@ -354,8 +378,39 @@ class App(tb.Window):
                     eng.llm.set_api_key(oai)
             except Exception:
                 pass
-        self.log_append("[API] Claves actualizadas")
-        self._lock_controls(False)
+        try:
+            bin_ok, llm_ok, codex_ok = await asyncio.gather(*tasks)
+        except Exception:
+            bin_ok = llm_ok = codex_ok = False
+        self.mass_state.apis_verified = {
+            "binance": bool(bin_ok),
+            "llm": bool(llm_ok),
+            "codex": bool(codex_ok),
+        }
+        self.mass_state.save()
+        self.after(0, lambda: self.auth_frame.update_badges(self.mass_state.apis_verified))
+        self.after(0, lambda: self.log_append("[API] Verificación completada"))
+        self.after(0, self._apply_api_locks)
+
+    def _apply_api_locks(self) -> None:
+        """Habilita o deshabilita controles según verificación de APIs."""
+        bin_ok = self.mass_state.apis_verified.get("binance", False)
+        llm_ok = self.mass_state.apis_verified.get("llm", False)
+        codex_ok = self.mass_state.apis_verified.get("codex", False)
+        self._lock_controls(not (bin_ok and llm_ok))
+        codex_needed = self.var_use_codex.get()
+        for btn in getattr(self, "_codex_buttons", []):
+            try:
+                btn.configure(state="normal")
+            except Exception:
+                pass
+        if codex_needed and not codex_ok:
+            for btn in getattr(self, "_codex_buttons", []):
+                try:
+                    btn.configure(state="disabled")
+                except Exception:
+                    pass
+            self.log_append("[Codex] API inválida")
 
     def _on_engine_snapshot(self, snap: Dict[str, Any]):
         """Callback para recibir snapshots del motor."""
@@ -479,11 +534,25 @@ class App(tb.Window):
             self.log_append("[TEST] Valor inválido para órdenes mínimas")
 
     # ------------------- Testeos masivos -------------------
-    def on_toggle_mass_tests(self, running: bool) -> None:
+    def on_toggle_mass_tests(self, running: bool, params: Dict[str, Any]) -> None:
         """Inicia o detiene los ciclos de testeos masivos."""
         if running:
             self.log_append("[TEST] Iniciar Testeos presionado")
-            self._supervisor.start_mass_tests()
+            if not (
+                self.mass_state.apis_verified.get("binance")
+                and self.mass_state.apis_verified.get("llm")
+            ):
+                self.log_append("[TEST] APIs no verificadas")
+                self.testeos_frame.btn_toggle.configure(text="Iniciar Testeos", bootstyle=SUCCESS)
+                return
+            st = self._supervisor.state
+            st.max_depth_symbols = int(params.get("max_depth_symbols", st.max_depth_symbols))
+            st.depth_speed = params.get("depth_speed", st.depth_speed)
+            st.bots_per_cycle = int(params.get("num_bots", st.bots_per_cycle))
+            st.mode = params.get("mode", st.mode)
+            st.save()
+            self._supervisor.mode = st.mode
+            self._supervisor.start_mass_tests(num_bots=st.bots_per_cycle)
         else:
             self.log_append("[TEST] Testeos detenidos")
             self._supervisor.stop_mass_tests()


### PR DESCRIPTION
## Summary
- centralize MarketDataHub initialization within Supervisor and manage depth subscriptions per cycle
- add UI controls for depth limits, speed, mode and bot count
- persist tuning parameters in application state and allow runtime configuration
- add asynchronous API credential verification for Binance, LLM and Codex with UI badges and gating

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1404632088328b31840fe8ee2cf1a