### PR TITLE
Propaga clave OpenAI al supervisor

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -39,6 +39,20 @@ class LLMClient:
                 self._client = None
 
     # ------------------------------------------------------------------
+    def set_api_key(self, api_key: str) -> None:
+        """Actualiza la clave de API y reconfigura el cliente interno."""
+        self.api_key = api_key or ""
+        if self.api_key:
+            try:
+                from openai import OpenAI  # type: ignore
+
+                self._client = OpenAI(api_key=self.api_key)
+            except Exception:
+                self._client = None
+        else:
+            self._client = None
+
+    # ------------------------------------------------------------------
     def check_credentials(self) -> bool:
         """Verifies that the configured API key is valid.
 

--- a/ui_app.py
+++ b/ui_app.py
@@ -359,6 +359,7 @@ class App(tb.Window):
         sec = self.var_bin_sec.get().strip()
         oai = self.var_oai_key.get().strip()
         codex_key = self.var_codex_key.get().strip()
+        os.environ["OPENAI_API_KEY"] = oai
         llm_client = MassLLMClient(api_key=oai)
         codex_client = CodexClient(api_key=codex_key)
         tasks = [
@@ -378,6 +379,10 @@ class App(tb.Window):
                     eng.llm.set_api_key(oai)
             except Exception:
                 pass
+        try:
+            self._supervisor.llm.set_api_key(oai)
+        except Exception:
+            pass
         try:
             bin_ok, llm_ok, codex_ok = await asyncio.gather(*tasks)
         except Exception:


### PR DESCRIPTION
## Summary
- Add API key setter to LLM client to rebuild internal OpenAI client
- Update UI flow to export provided OpenAI key, reuse in supervisor and engines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a149fbc5188328b8f1014c99b430ac