### PR TITLE
Show LLM logs in info panel

### DIFF
--- a/components/info_frame.py
+++ b/components/info_frame.py
@@ -1,0 +1,83 @@
+import json
+import queue
+import tkinter as tk
+from typing import Any, Callable
+
+from ttkbootstrap.constants import *
+from ttkbootstrap.scrolled import ScrolledText
+from tkinter import ttk
+
+
+class InfoFrame(ttk.Labelframe):
+    """Frame que muestra información y logs del LLM."""
+
+    def __init__(
+        self,
+        parent: ttk.Widget,
+        var_min_orders: tk.IntVar,
+        on_apply_min_orders: Callable[[], None],
+        on_revert_patch: Callable[[], None],
+        on_apply_winner_live: Callable[[], None],
+    ) -> None:
+        super().__init__(parent, text="Información / Razones", padding=8)
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        self._log_queue: "queue.Queue[str]" = queue.Queue()
+        self.var_pause_logs = tk.BooleanVar(value=False)
+
+        self.txt_logs = ScrolledText(self, height=6, autohide=True, wrap="word")
+        self.txt_logs.grid(row=0, column=0, columnspan=2, sticky="nsew")
+
+        ttk.Label(self, text="Órdenes mínimas").grid(row=1, column=0, sticky="w")
+        ttk.Entry(self, textvariable=var_min_orders, width=10).grid(row=1, column=1, sticky="e")
+        ttk.Button(
+            self,
+            text="Aplicar mín. órdenes",
+            command=on_apply_min_orders,
+        ).grid(row=2, column=0, columnspan=2, sticky="ew", pady=(4, 0))
+        ttk.Button(self, text="Revertir patch", command=on_revert_patch).grid(
+            row=3, column=0, sticky="ew", pady=(4, 0)
+        )
+        ttk.Button(self, text="Aplicar a LIVE", command=on_apply_winner_live).grid(
+            row=3, column=1, sticky="ew", pady=(4, 0)
+        )
+
+        ctrl = ttk.Frame(self)
+        ctrl.grid(row=4, column=0, columnspan=2, sticky="w", pady=(4, 0))
+        ttk.Checkbutton(ctrl, text="Pausar logs", variable=self.var_pause_logs).grid(
+            row=0, column=0, sticky="w"
+        )
+        ttk.Button(ctrl, text="Limpiar", command=self.clear_logs).grid(
+            row=0, column=1, padx=(8, 0)
+        )
+
+        self.after(200, self._process_log_queue)
+
+    # ------------------------------------------------------------------
+    def append_llm_log(self, tag: str, payload: Any) -> None:
+        """Encola eventos del LLM para mostrarlos."""
+        try:
+            text = (
+                json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+                if not isinstance(payload, str)
+                else payload
+            )
+        except Exception:
+            text = str(payload)
+        self._log_queue.put(f"[LLM {tag}] {text}")
+
+    def _process_log_queue(self) -> None:
+        if not self.var_pause_logs.get():
+            try:
+                while True:
+                    line = self._log_queue.get_nowait()
+                    self.txt_logs.insert("end", line + "\n")
+                    self.txt_logs.see("end")
+            except queue.Empty:
+                pass
+        self.after(200, self._process_log_queue)
+
+    def clear_logs(self) -> None:
+        self.txt_logs.delete("1.0", "end")

--- a/llm/client.py
+++ b/llm/client.py
@@ -62,22 +62,26 @@ class LLMClient:
         """
         if not self.api_key:
             self._client = None
-            
+
             return False
         try:
             import requests
 
+            url = "https://api.openai.com/v1/models"
+            self._log("request", {"url": url})
             resp = requests.get(
-                "https://api.openai.com/v1/models",
+                url,
                 headers={"Authorization": f"Bearer {self.api_key}"},
                 timeout=5,
             )
+            self._log("response", {"status": resp.status_code})
             if resp.status_code == 200:
                 return True
             self._client = None
             return False
-        except Exception:
+        except Exception as e:
             self._client = None
+            self._log("response", {"error": str(e)})
 
             return False
 


### PR DESCRIPTION
## Summary
- Add InfoFrame widget with LLM log channel, pause and clear controls
- Wrap OpenAI credential checks with request/response logging
- Wire LLM client logs to new Information/Razones panel and remove other log outputs

## Testing
- `python -m pytest tests/test_llm_client.py::test_generate_initial_variations_extracts_json -q`
- `python -m pytest tests/test_llm_client.py::test_analyze_cycle_extracts_json_from_code_block -q`
- `python -m pytest tests/test_llm_client.py::test_new_generation_extracts_json_from_code_block -q`

------
https://chatgpt.com/codex/tasks/task_e_68a156c1952c83289c7aed5f88a42c62