### PR TITLE
feat: load meta-winner into sim bot

### DIFF
--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -54,3 +54,13 @@ Genera 10 NUEVAS variaciones cercanas (mutaciones locales pequeñas), todas dist
 Formato: igual que el prompt inicial (name + mutations). Devuelve JSON parseable.
 Evita duplicados: usa fingerprints (hashes) de conjuntos de parámetros que te paso.
 """
+
+PROMPT_META_GANADOR = """
+Te paso una lista de ganadores históricos. Cada elemento incluye cycle, bot_id,
+mutations y stats (orders, pnl, pnl_pct, wins, losses, runtime_s).
+Elige UN meta-ganador con criterio multi-métrica: prioriza pnl y pnl_pct, pero
+también win_rate alto y estabilidad. Penaliza pérdidas o comportamientos
+inconsistentes.
+Devuelve JSON: { "bot_id": <int>, "reason": "<breve explicación>" }.
+El JSON debe ser parseable. Nada más.
+"""

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -44,3 +44,15 @@ def test_new_generation_extracts_json_from_code_block():
     res = client.new_generation_from_winner({}, [])
     assert res[0]["name"] == "foo"
     assert len(res) == 10
+
+
+def test_pick_meta_winner_extracts_json():
+    content = "```json\n{\"bot_id\": 2, \"reason\": \"best pnl\"}\n```"
+    client = LLMClient(api_key="")
+    client._client = DummyClient(content)
+    winners = [
+        {"cycle": 1, "bot_id": 1, "mutations": {}, "stats": {"pnl": 1}},
+        {"cycle": 2, "bot_id": 2, "mutations": {}, "stats": {"pnl": 2}},
+    ]
+    res = client.pick_meta_winner(winners)
+    assert res["bot_id"] == 2

--- a/ui_app.py
+++ b/ui_app.py
@@ -108,6 +108,8 @@ class App(tb.Window):
         self._build_ui()
         # Instanciar LLM y supervisor después de construir UI para cablear logs
         llm_client = MassLLMClient(on_log=self.info_frame.append_llm_log)
+        # guardar referencia para futuras consultas (meta-ganador, etc.)
+        self.llm_client = llm_client
         self._supervisor = Supervisor(
             app_state=self.mass_state,
             llm_client=llm_client,
@@ -534,20 +536,48 @@ class App(tb.Window):
             self._supervisor.stop_mass_tests()
 
     def on_load_winner_for_sim(self) -> None:
-        """Carga la configuración ganadora en el bot SIM."""
-        if not self._winner_cfg:
-            self.log_append("[TEST] No hay ganador disponible")
+        """Selecciona meta-ganador histórico y lo carga en el bot SIM."""
+        try:
+            winners = self._supervisor.storage.list_winners()
+        except Exception:
+            winners = []
+
+        if not winners:
+            self.log_append("[TEST] No hay ganadores históricos")
             return
+
+        # Pedir al LLM que elija el meta-ganador
+        try:
+            res = self.llm_client.pick_meta_winner(winners)
+            bot_id = res.get("bot_id")
+            reason = res.get("reason", "")
+        except Exception:
+            bot_id = None
+            reason = ""
+
+        if bot_id is None:
+            self.log_append("[TEST] No se pudo determinar meta-ganador")
+            return
+
+        cfg = self._supervisor.storage.get_bot(int(bot_id))
+        if not cfg:
+            self.log_append("[TEST] Configuración del ganador no encontrada")
+            return
+
+        # Guardar para posible uso posterior (aplicar a LIVE)
+        self._winner_cfg = cfg
+
         try:
             if self._engine_sim and self._engine_sim.is_alive():
                 self._engine_sim.stop()
-            self._engine_sim = load_sim_config(self._winner_cfg.mutations)
+            self._engine_sim = load_sim_config(cfg.mutations)
             self._engine_sim.start()
             self.var_bot_sim.set(True)
             self.lbl_state_sim.configure(text="SIM: ON", bootstyle=SUCCESS)
-            self.log_append("[TEST] Bot ganador cargado en modo SIM")
+            self.info_frame.append_llm_log("meta_winner", {"bot_id": bot_id, "reason": reason})
+            self.log_append("[TEST] Bot meta-ganador cargado en modo SIM")
         except Exception as exc:
-            self.log_append(f"[TEST] Error al cargar ganador: {exc}")
+            self.log_append(f"[TEST] Error al cargar meta-ganador: {exc}")
 
     # ------------------- Log helpers -------------------
     def log_append(self, msg: str):


### PR DESCRIPTION
## Summary
- add SQLiteStorage.list_winners to provide historical cycle winners
- introduce PROMPT_META_GANADOR and LLM client helper to pick meta winner
- button 'Subir Bot Sim' now selects meta-winner via LLM and loads it into SIM engine

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1c85dafa083289a346f6707f33357