### PR TITLE
feat: load meta-winner into sim bot

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -11,7 +11,18 @@ from .prompts import (
     PROMPT_ANALISIS_CICLO,
     PROMPT_NUEVA_GENERACION_DESDE_GANADOR,
     PROMPT_P0,
+    PROMPT_META_GANADOR,
 )
+
+# Pesos por defecto para el análisis local de ciclos
+DEFAULT_METRIC_WEIGHTS: Dict[str, float] = {
+    "pnl": 0.35,
+    "timeouts": 0.25,
+    "slippage": 0.2,
+    "win_rate": 0.1,
+    "avg_hold_s": 0.06,
+    "cancel_replace_count": 0.04,
+}
 
 class LLMClient:
     """Wrapper liviano sobre OpenAI que genera variaciones iniciales.
@@ -336,11 +347,15 @@ class LLMClient:
         return unique
 
     # ------------------------------------------------------------------
-    def analyze_cycle_and_pick_winner(self, cycle_summary: Dict[str, object]) -> Dict[str, object]:
+    def analyze_cycle_and_pick_winner(
+        self,
+        cycle_summary: Dict[str, object],
+        weights: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, object]:
         """Analiza un resumen de ciclo y elige un ganador.
 
-        Si la llamada al LLM falla o no hay API key, se usa como
-        fallback el bot con mayor PNL.
+        Si la llamada al LLM falla o no hay API key, se recurre a un
+        cálculo local basado en un score ponderado de múltiples métricas.
         """
 
         if self._client is not None:
@@ -368,30 +383,137 @@ class LLMClient:
                 self._log("response", {"error": "no json object", "raw": raw_txt})
             except Exception as e:
                 self._log("response", {"error": str(e)})
-        return self._fallback_winner(cycle_summary)
+        return self.pick_winner_local(cycle_summary, weights)
 
     # ------------------------------------------------------------------
-    def _fallback_winner(self, cycle_summary: Dict[str, object]) -> Dict[str, object]:
-        """Fallback determinista seleccionando el bot con mayor PnL.
-
-        Se recorre la lista de bots provista en ``cycle_summary`` y se
-        identifica el ``bot_id`` con mayor beneficio acumulado. Este camino
-        es utilizado cuando la llamada al LLM falla o no se dispone de clave
-        de API, evitando que el ciclo quede sin ganador.
-        """
-
-        bots = cycle_summary.get("bots", [])
-        best_id = None
-        best_pnl = float("-inf")
-        for bot in bots:
+    def pick_meta_winner(self, winners: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Elige un meta-ganador entre ganadores históricos."""
+        if self._client is not None:
+            messages = [
+                {"role": "system", "content": PROMPT_P0},
+                {"role": "system", "content": PROMPT_META_GANADOR},
+                {"role": "user", "content": json.dumps(winners)},
+            ]
+            self._log("request", {"model": self.model, "messages": messages})
             try:
-                pnl = float(bot.get("stats", {}).get("pnl", float("-inf")))
+                resp = self._client.chat.completions.create(
+                    model=self.model,
+                    temperature=0,
+                    messages=messages,
+                    timeout=40,
+                )
+                raw_txt = resp.choices[0].message.content or "{}"
+                self._log("response", raw_txt)
+                data = self._extract_json(raw_txt)
+                if isinstance(data, dict) and "bot_id" in data:
+                    return {
+                        "bot_id": int(data.get("bot_id", -1)),
+                        "reason": str(data.get("reason", "")),
+                    }
+                self._log("response", {"error": "no json object", "raw": raw_txt})
+            except Exception as e:
+                self._log("response", {"error": str(e)})
+        return self._fallback_meta_winner(winners)
+
+    def _fallback_meta_winner(self, winners: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Fallback determinista: selecciona el ganador con mayor PnL."""
+        best = None
+        best_pnl = float("-inf")
+        for w in winners:
+            try:
+                pnl = float(w.get("stats", {}).get("pnl", float("-inf")))
             except Exception:
                 pnl = float("-inf")
             if pnl > best_pnl:
                 best_pnl = pnl
-                best_id = bot.get("bot_id")
-        return {
-            "winner_bot_id": int(best_id) if best_id is not None else -1,
-            "reason": "max_pnl",
-        }
+                best = w
+        if best:
+            return {
+                "bot_id": int(best.get("bot_id", -1)),
+                "reason": "max_pnl",
+            }
+        return {"bot_id": -1, "reason": "no_winners"}
+
+    # ------------------------------------------------------------------
+    def pick_winner_local(
+        self,
+        cycle_summary: Dict[str, object],
+        weights: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, object]:
+        """Selecciona un ganador mediante score ponderado.
+
+        ``weights`` permite ajustar la importancia relativa de cada métrica.
+        Los pesos que no se provean se completan con valores por defecto
+        ``DEFAULT_METRIC_WEIGHTS``. Se prioriza PnL, luego estabilidad
+        (timeouts y slippage), seguido de win rate, menor tiempo de hold y
+        menor cancelación/reemplazo. Los empates se resuelven de manera
+        determinista siguiendo el mismo orden de métricas.
+        """
+
+        bots = cycle_summary.get("bots", [])
+        if not bots:
+            return {"winner_bot_id": -1, "reason": "no_bots"}
+
+        w = DEFAULT_METRIC_WEIGHTS.copy()
+        if weights:
+            w.update(weights)
+
+        # recopilar valores por métrica
+        pnl_vals = [float(b.get("stats", {}).get("pnl", 0.0)) for b in bots]
+        timeout_vals = [float(b.get("stats", {}).get("timeouts", 0.0)) for b in bots]
+        slippage_vals = [float(b.get("stats", {}).get("avg_slippage_ticks", 0.0)) for b in bots]
+        win_vals = [float(b.get("stats", {}).get("win_rate", 0.0)) for b in bots]
+        hold_vals = [float(b.get("stats", {}).get("avg_hold_s", 0.0)) for b in bots]
+        crc_vals = [
+            float(b.get("stats", {}).get("cancel_replace_count", 0.0)) for b in bots
+        ]
+
+        def norm(val: float, vals: List[float], invert: bool = False) -> float:
+            mn = min(vals)
+            mx = max(vals)
+            if mx == mn:
+                res = 0.0
+            else:
+                res = (val - mn) / (mx - mn)
+            return 1 - res if invert else res
+
+        scored: List[Dict[str, float]] = []
+        for idx, bot in enumerate(bots):
+            score = (
+                w["pnl"] * norm(pnl_vals[idx], pnl_vals)
+                + w["timeouts"] * norm(timeout_vals[idx], timeout_vals, invert=True)
+                + w["slippage"] * norm(slippage_vals[idx], slippage_vals, invert=True)
+                + w["win_rate"] * norm(win_vals[idx], win_vals)
+                + w["avg_hold_s"] * norm(hold_vals[idx], hold_vals, invert=True)
+                + w["cancel_replace_count"]
+                * norm(crc_vals[idx], crc_vals, invert=True)
+            )
+            scored.append(
+                {
+                    "bot_id": int(bot.get("bot_id", -1)),
+                    "score": score,
+                    "pnl": pnl_vals[idx],
+                    "timeouts": timeout_vals[idx],
+                    "slippage": slippage_vals[idx],
+                    "win_rate": win_vals[idx],
+                    "avg_hold_s": hold_vals[idx],
+                    "cancel_replace_count": crc_vals[idx],
+                }
+            )
+
+        scored.sort(
+            key=lambda b: (
+                b["score"],
+                b["pnl"],
+                -b["timeouts"],
+                -b["slippage"],
+                b["win_rate"],
+                -b["avg_hold_s"],
+                -b["cancel_replace_count"],
+                -b["bot_id"],
+            ),
+            reverse=True,
+        )
+
+        winner = scored[0]
+        return {"winner_bot_id": winner["bot_id"], "reason": "weighted_score"}

--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -38,8 +38,13 @@ Valida que el JSON sea parseable.
 """
 
 PROMPT_ANALISIS_CICLO = """
-Te paso un resumen del ciclo con 10 bots. Para cada bot: mutations, stats (orders, pnl, pnl_pct, win_rate, avg_hold_s, avg_slippage_ticks, timeouts, cancel_replace_count), top-3 pares por PnL, distribución de resultados por hora.
-Tarea: Elige UN ganador priorizando PNL y estabilidad (menor varianza y menos timeouts/slippage). Penaliza configuraciones con drawdowns altos o comportamiento errático. Devuelve JSON:
+Te paso un resumen del ciclo con 10 bots. Para cada bot: mutations, stats (orders, pnl,
+pnl_pct, win_rate, avg_hold_s, avg_slippage_ticks, timeouts, cancel_replace_count),
+top-3 pares por PnL y distribución de resultados por hora.
+Tarea: Elige UN ganador priorizando PNL, luego estabilidad (menos timeouts y slippage),
+después win_rate, luego menor avg_hold_s y finalmente menor cancel_replace_count. Puedes
+elegir un bot que despunte claramente en un aspecto clave aunque no tenga el mayor PNL.
+Devuelve JSON:
 { "winner_bot_id": <int>, "reason": "<breve explicación>" }
 El JSON debe ser parseable. Nada más.
 """
@@ -53,4 +58,14 @@ Genera 10 NUEVAS variaciones cercanas (mutaciones locales pequeñas), todas dist
 - Regla central de venta +1 tick puede extenderse a +k_ticks con max_wait_s, siempre cubriendo comisiones.
 Formato: igual que el prompt inicial (name + mutations). Devuelve JSON parseable.
 Evita duplicados: usa fingerprints (hashes) de conjuntos de parámetros que te paso.
+"""
+
+PROMPT_META_GANADOR = """
+Te paso una lista de ganadores históricos. Cada elemento incluye cycle, bot_id,
+mutations y stats (orders, pnl, pnl_pct, wins, losses, runtime_s).
+Elige UN meta-ganador con criterio multi-métrica: prioriza pnl y pnl_pct, pero
+también win_rate alto y estabilidad. Penaliza pérdidas o comportamientos
+inconsistentes.
+Devuelve JSON: { "bot_id": <int>, "reason": "<breve explicación>" }.
+El JSON debe ser parseable. Nada más.
 """

--- a/state/app_state.py
+++ b/state/app_state.py
@@ -20,6 +20,16 @@ class AppState:
     apis_verified: Dict[str, bool] = field(
         default_factory=lambda: {"binance": False, "llm": False}
     )
+    metric_weights: Dict[str, float] = field(
+        default_factory=lambda: {
+            "pnl": 0.35,
+            "timeouts": 0.25,
+            "slippage": 0.2,
+            "win_rate": 0.1,
+            "avg_hold_s": 0.06,
+            "cancel_replace_count": 0.04,
+        }
+    )
     _file: str = field(init=False, repr=False)
 
     def __post_init__(self) -> None:

--- a/ui_app.py
+++ b/ui_app.py
@@ -108,6 +108,8 @@ class App(tb.Window):
         self._build_ui()
         # Instanciar LLM y supervisor después de construir UI para cablear logs
         llm_client = MassLLMClient(on_log=self.info_frame.append_llm_log)
+        # guardar referencia para futuras consultas (meta-ganador, etc.)
+        self.llm_client = llm_client
         self._supervisor = Supervisor(
             app_state=self.mass_state,
             llm_client=llm_client,
@@ -534,20 +536,48 @@ class App(tb.Window):
             self._supervisor.stop_mass_tests()
 
     def on_load_winner_for_sim(self) -> None:
-        """Carga la configuración ganadora en el bot SIM."""
-        if not self._winner_cfg:
-            self.log_append("[TEST] No hay ganador disponible")
+        """Selecciona meta-ganador histórico y lo carga en el bot SIM."""
+        try:
+            winners = self._supervisor.storage.list_winners()
+        except Exception:
+            winners = []
+
+        if not winners:
+            self.log_append("[TEST] No hay ganadores históricos")
             return
+
+        # Pedir al LLM que elija el meta-ganador
+        try:
+            res = self.llm_client.pick_meta_winner(winners)
+            bot_id = res.get("bot_id")
+            reason = res.get("reason", "")
+        except Exception:
+            bot_id = None
+            reason = ""
+
+        if bot_id is None:
+            self.log_append("[TEST] No se pudo determinar meta-ganador")
+            return
+
+        cfg = self._supervisor.storage.get_bot(int(bot_id))
+        if not cfg:
+            self.log_append("[TEST] Configuración del ganador no encontrada")
+            return
+
+        # Guardar para posible uso posterior (aplicar a LIVE)
+        self._winner_cfg = cfg
+
         try:
             if self._engine_sim and self._engine_sim.is_alive():
                 self._engine_sim.stop()
-            self._engine_sim = load_sim_config(self._winner_cfg.mutations)
+            self._engine_sim = load_sim_config(cfg.mutations)
             self._engine_sim.start()
             self.var_bot_sim.set(True)
             self.lbl_state_sim.configure(text="SIM: ON", bootstyle=SUCCESS)
-            self.log_append("[TEST] Bot ganador cargado en modo SIM")
+            self.info_frame.append_llm_log("meta_winner", {"bot_id": bot_id, "reason": reason})
+            self.log_append("[TEST] Bot meta-ganador cargado en modo SIM")
         except Exception as exc:
-            self.log_append(f"[TEST] Error al cargar ganador: {exc}")
+            self.log_append(f"[TEST] Error al cargar meta-ganador: {exc}")
 
     # ------------------- Log helpers -------------------
     def log_append(self, msg: str):


### PR DESCRIPTION
## Summary
- refine cycle analysis prompt to weigh PnL, stability and other metrics
- add configurable metric weights and local weighted fallback when LLM analysis fails
- persist winner reasoning in cycle summaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1c85dafa083289a346f6707f33357