### PR TITLE
feat: periodic global analysis with LLM

### DIFF
--- a/components/info_frame.py
+++ b/components/info_frame.py
@@ -23,6 +23,7 @@ class InfoFrame(ttk.Labelframe):
         on_apply_min_orders: Callable[[], None],
         on_revert_patch: Callable[[], None],
         on_apply_winner_live: Callable[[], None],
+        on_submit_patch: Callable[[], None],
     ) -> None:
         super().__init__(parent, text="Información / Razones", padding=8)
         self.columnconfigure(0, weight=1)
@@ -46,6 +47,9 @@ class InfoFrame(ttk.Labelframe):
         )
         ttk.Button(self, text="Aplicar a LIVE", command=on_apply_winner_live).grid(
             row=3, column=1, sticky="ew", pady=(4, 0)
+        )
+        ttk.Button(self, text="Crear PR patch", command=on_submit_patch).grid(
+            row=4, column=0, columnspan=2, sticky="ew", pady=(4, 0)
         )
 
         self.after(200, self._process_log_queue)

--- a/components/settings_frame.py
+++ b/components/settings_frame.py
@@ -1,0 +1,42 @@
+"""Settings frame containing order-size controls for SIM and LIVE engines."""
+
+import ttkbootstrap as tb
+from tkinter import ttk
+
+
+class SettingsFrame(ttk.Frame):
+    """Controles de tamaño por operación y mínimo de Binance."""
+
+    def __init__(self, master, apply_cb, toggle_min_cb, cfg) -> None:
+        super().__init__(master, padding=0)
+        self.columnconfigure(0, weight=1)
+
+        frm_size = ttk.Labelframe(self, text="Tamaño por operación (USD)", padding=8)
+        frm_size.grid(row=0, column=0, sticky="ew", pady=6)
+        frm_size.columnconfigure(1, weight=1)
+
+        # Variables expuestas
+        self.var_size_sim = tb.DoubleVar(value=getattr(cfg, "size_usd_sim", 50.0))
+        self.var_size_live = tb.DoubleVar(value=getattr(cfg, "size_usd_live", 50.0))
+        self.var_use_min_bin = tb.BooleanVar(value=False)
+
+        ttk.Label(frm_size, text="SIM").grid(row=0, column=0, sticky="w")
+        self.ent_size_sim = ttk.Entry(frm_size, textvariable=self.var_size_sim, width=12)
+        self.ent_size_sim.grid(row=0, column=1, sticky="ew", padx=(4, 4))
+
+        ttk.Label(frm_size, text="LIVE").grid(row=1, column=0, sticky="w")
+        self.ent_size_live = ttk.Entry(frm_size, textvariable=self.var_size_live, width=12)
+        self.ent_size_live.grid(row=1, column=1, sticky="ew", padx=(4, 4))
+
+        ttk.Checkbutton(
+            frm_size,
+            text="Mínimo Binance",
+            variable=self.var_use_min_bin,
+            command=toggle_min_cb,
+            bootstyle="round-toggle",
+        ).grid(row=1, column=2, padx=(6, 0))
+
+        ttk.Button(frm_size, text="Aplicar", command=apply_cb).grid(row=0, column=2, padx=(6, 0))
+
+        self.lbl_min_marker = ttk.Label(frm_size, text="Mínimo Binance: --")
+        self.lbl_min_marker.grid(row=2, column=0, columnspan=3, sticky="w", pady=(4, 0))

--- a/components/testeos_frame.py
+++ b/components/testeos_frame.py
@@ -23,16 +23,46 @@ class TesteosFrame(ttk.Frame):
 
     def _build(self) -> None:
         """Construye los widgets principales."""
-        self.columnconfigure(0, weight=1)
-        self.rowconfigure(1, weight=1)
-        self.rowconfigure(4, weight=1)
+        self.columnconfigure(0, weight=3)
+        self.columnconfigure(1, weight=2)
+        self.rowconfigure(0, weight=1)
 
         self.var_num_bots = tk.IntVar(value=10)
         self.var_max_depth = tk.IntVar(value=20)
         self.var_depth_speed = tk.StringVar(value="100ms")
         self.var_mode = tk.StringVar(value="SIM")
 
-        top = ttk.Frame(self)
+        # Tabla de bots fija
+        tbl_frame = ttk.Frame(self)
+        tbl_frame.grid(row=0, column=0, sticky="nsew")
+        tbl_frame.columnconfigure(0, weight=1)
+        tbl_frame.rowconfigure(0, weight=1)
+
+        cols = ("bot_id", "cycle", "orders", "pnl", "status", "winner")
+        self.tree = ttk.Treeview(tbl_frame, columns=cols, show="headings", height=10)
+        headings = [
+            ("bot_id", "BotID", 80),
+            ("cycle", "Ciclo", 80),
+            ("orders", "Órdenes", 100),
+            ("pnl", "PNL", 100),
+            ("status", "Estado", 120),
+            ("winner", "EsGanador", 100),
+        ]
+        for col, txt, width in headings:
+            self.tree.heading(col, text=txt)
+            self.tree.column(col, width=width, anchor="center", stretch=True)
+        vsb = ttk.Scrollbar(tbl_frame, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=vsb.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+
+        # Panel lateral con controles e historial
+        side = ttk.Frame(self, padding=(8, 0, 0, 0))
+        side.grid(row=0, column=1, sticky="nsew")
+        side.columnconfigure(0, weight=1)
+        side.rowconfigure(3, weight=1)
+
+        top = ttk.Frame(side)
         top.grid(row=0, column=0, sticky="w")
         self.btn_toggle = ttk.Button(
             top,
@@ -66,33 +96,15 @@ class TesteosFrame(ttk.Frame):
             textvariable=self.var_mode,
         ).grid(row=0, column=8)
 
-        cols = ("bot_id", "cycle", "orders", "pnl", "status", "winner")
-        self.tree = ttk.Treeview(self, columns=cols, show="headings", height=10)
-        headings = [
-            ("bot_id", "BotID", 80),
-            ("cycle", "Ciclo", 80),
-            ("orders", "Órdenes", 100),
-            ("pnl", "PNL", 100),
-            ("status", "Estado", 120),
-            ("winner", "EsGanador", 100),
-        ]
-        for col, txt, width in headings:
-            self.tree.heading(col, text=txt)
-            self.tree.column(col, width=width, anchor="center", stretch=True)
-        vsb = ttk.Scrollbar(self, orient="vertical", command=self.tree.yview)
-        self.tree.configure(yscrollcommand=vsb.set)
-        self.tree.grid(row=1, column=0, sticky="nsew")
-        vsb.grid(row=1, column=1, sticky="ns")
-
         ttk.Button(
-            self, text="Subir Bot Sim", command=self.on_load_winner_for_sim
-        ).grid(row=2, column=0, sticky="w", pady=(8, 0))
+            side, text="Subir Bot Sim", command=self.on_load_winner_for_sim
+        ).grid(row=1, column=0, sticky="w", pady=(8, 0))
 
-        self.lbl_winner = ttk.Label(self, text="Ganador: -", anchor="w")
-        self.lbl_winner.grid(row=3, column=0, sticky="w", pady=(6, 0))
+        self.lbl_winner = ttk.Label(side, text="Ganador: -", anchor="w")
+        self.lbl_winner.grid(row=2, column=0, sticky="w", pady=(6, 0))
 
         cols_c = ("cycle", "pnl", "winner", "reason", "fecha")
-        self.tree_cycles = ttk.Treeview(self, columns=cols_c, show="headings", height=5)
+        self.tree_cycles = ttk.Treeview(side, columns=cols_c, show="headings", height=5)
         for c, txt, w in [
             ("cycle", "Ciclo", 80),
             ("pnl", "PNL Total", 100),
@@ -102,10 +114,10 @@ class TesteosFrame(ttk.Frame):
         ]:
             self.tree_cycles.heading(c, text=txt)
             self.tree_cycles.column(c, width=w, anchor="center", stretch=True)
-        vsb_c = ttk.Scrollbar(self, orient="vertical", command=self.tree_cycles.yview)
+        vsb_c = ttk.Scrollbar(side, orient="vertical", command=self.tree_cycles.yview)
         self.tree_cycles.configure(yscrollcommand=vsb_c.set)
-        self.tree_cycles.grid(row=4, column=0, sticky="nsew", pady=(8, 0))
-        vsb_c.grid(row=4, column=1, sticky="ns")
+        self.tree_cycles.grid(row=3, column=0, sticky="nsew", pady=(8, 0))
+        vsb_c.grid(row=3, column=1, sticky="ns")
 
     def _toggle(self) -> None:
         """Alterna el estado de los testeos y actualiza el botón."""

--- a/engine/strategy_params.py
+++ b/engine/strategy_params.py
@@ -27,6 +27,7 @@ class Params:
     """Concrete parameters consumed by :mod:`strategy_base`."""
 
     order_size_usd: float = 50.0
+    min_notional_margin: float = 1.0
     buy_level_rule: str = "accum_bids"
     sell_k_ticks: int = 1
     max_wait_s: int = 30
@@ -42,7 +43,9 @@ def _clamp(value: float, low: float, high: float) -> float:
     return max(low, min(high, value))
 
 
-def map_mutations_to_params(mutations: Dict[str, Any] | None) -> Params:
+def map_mutations_to_params(
+    mutations: Dict[str, Any] | None, order_size_usd: float | None = None
+) -> Params:
     """Translate mutation dictionaries into :class:`Params`.
 
     Unknown keys are ignored. Basic validation/clamping is applied so the
@@ -56,6 +59,12 @@ def map_mutations_to_params(mutations: Dict[str, Any] | None) -> Params:
     if "order_size_usd" in mutations:
         try:
             params.order_size_usd = float(mutations["order_size_usd"])
+        except (TypeError, ValueError):
+            pass
+
+    if "min_notional_margin" in mutations:
+        try:
+            params.min_notional_margin = float(mutations["min_notional_margin"])
         except (TypeError, ValueError):
             pass
 
@@ -92,6 +101,12 @@ def map_mutations_to_params(mutations: Dict[str, Any] | None) -> Params:
         params.risk_limits.per_pair_exposure_usd = float(
             rl.get("per_pair_exposure_usd", params.risk_limits.per_pair_exposure_usd)
         )
+
+    if order_size_usd is not None:
+        try:
+            params.order_size_usd = float(order_size_usd)
+        except (TypeError, ValueError):
+            pass
 
     return params
 

--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -38,8 +38,13 @@ Valida que el JSON sea parseable.
 """
 
 PROMPT_ANALISIS_CICLO = """
-Te paso un resumen del ciclo con 10 bots. Para cada bot: mutations, stats (orders, pnl, pnl_pct, win_rate, avg_hold_s, avg_slippage_ticks, timeouts, cancel_replace_count), top-3 pares por PnL, distribución de resultados por hora.
-Tarea: Elige UN ganador priorizando PNL y estabilidad (menor varianza y menos timeouts/slippage). Penaliza configuraciones con drawdowns altos o comportamiento errático. Devuelve JSON:
+Te paso un resumen del ciclo con 10 bots. Para cada bot: mutations, stats (orders, pnl,
+pnl_pct, win_rate, avg_hold_s, avg_slippage_ticks, timeouts, cancel_replace_count),
+top-3 pares por PnL y distribución de resultados por hora.
+Tarea: Elige UN ganador priorizando PNL, luego estabilidad (menos timeouts y slippage),
+después win_rate, luego menor avg_hold_s y finalmente menor cancel_replace_count. Puedes
+elegir un bot que despunte claramente en un aspecto clave aunque no tenga el mayor PNL.
+Devuelve JSON:
 { "winner_bot_id": <int>, "reason": "<breve explicación>" }
 El JSON debe ser parseable. Nada más.
 """
@@ -53,4 +58,30 @@ Genera 10 NUEVAS variaciones cercanas (mutaciones locales pequeñas), todas dist
 - Regla central de venta +1 tick puede extenderse a +k_ticks con max_wait_s, siempre cubriendo comisiones.
 Formato: igual que el prompt inicial (name + mutations). Devuelve JSON parseable.
 Evita duplicados: usa fingerprints (hashes) de conjuntos de parámetros que te paso.
+"""
+
+PROMPT_META_GANADOR = """
+Te paso una lista de ganadores históricos. Cada elemento incluye cycle, bot_id,
+mutations y stats (orders, pnl, pnl_pct, wins, losses, runtime_s).
+Elige UN meta-ganador con criterio multi-métrica: prioriza pnl y pnl_pct, pero
+también win_rate alto y estabilidad. Penaliza pérdidas o comportamientos
+inconsistentes.
+Devuelve JSON: { "bot_id": <int>, "reason": "<breve explicación>" }.
+El JSON debe ser parseable. Nada más.
+"""
+
+PROMPT_ANALISIS_GLOBAL = """
+Te paso un resumen global con métricas por mutación, tendencias,
+mejores pares y estabilidad general. Propón 3-5 cambios accionables
+para mejorar el sistema de testeos y trading. Devuelve JSON:
+{
+  "changes": ["<breve cambio 1>", "<breve cambio 2>", ...]
+}
+El JSON debe ser parseable. Nada más.
+"""
+
+PROMPT_PATCH_FROM_CHANGES = """
+Te paso una lista de cambios accionables en formato JSON. Genera un patch
+unificado (diff) que implemente de manera aproximada esas sugerencias.
+Devuelve solo el diff en texto plano sin explicación adicional.
 """

--- a/orchestrator/supervisor.py
+++ b/orchestrator/supervisor.py
@@ -10,7 +10,7 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from llm import LLMClient
 from .models import BotConfig, BotStats, SupervisorEvent
@@ -70,7 +70,13 @@ class Supervisor:
         self.hub: Optional[MarketDataHub] = None
         self.exchange_meta: Optional[ExchangeMeta] = None
         self._last_symbols: set[str] = set()
+        self._order_size_usd: float = float(self.state.order_size_usd)
+        self._order_size_mode: str = str(self.state.order_size_mode)
+        self._active_runners: List[Any] = []
         self.min_orders_per_bot = int(min_orders)
+        self._global_thread: Optional[threading.Thread] = None
+        self._global_stop: Optional[threading.Event] = None
+        self._global_interval_s: int = 6 * 3600
 
     # ------------------------------------------------------------------
     # Streaming de eventos
@@ -107,6 +113,30 @@ class Supervisor:
         """Configura el mínimo de órdenes requerido por bot."""
         self.min_orders_per_bot = int(num)
 
+    def set_order_size_usd(self, size: float, mode: Optional[str] = None) -> None:
+        """Actualiza el tamaño por operación y lo propaga a los bots activos."""
+
+        self._order_size_usd = float(size)
+        if mode is not None:
+            self._order_size_mode = mode
+            self.state.order_size_mode = mode
+        self.state.order_size_usd = self._order_size_usd
+        self.state.save()
+        for cfg in self._current_generation:
+            muts = cfg.mutations or {}
+            muts["order_size_usd"] = self._order_size_usd
+            cfg.mutations = muts
+            self.storage.save_bot(cfg)
+        for r in list(self._active_runners):
+            try:
+                r.update_order_size(self._order_size_usd)
+            except Exception:
+                pass
+
+    def register_runner(self, runner: Any) -> None:
+        """Registra un ``BotRunner`` activo para broadcasts en caliente."""
+        self._active_runners.append(runner)
+
     # ------------------------------------------------------------------
     def start_mass_tests(self, num_bots: int = 10) -> None:
         """Inicia el ciclo continuo de testeos en un hilo aparte."""
@@ -136,6 +166,10 @@ class Supervisor:
         self._thread = threading.Thread(target=self._loop, daemon=True)
         self._thread.start()
 
+        # arranca también el scheduler de análisis global si no está activo
+        if not self._global_thread:
+            self.start_global_scheduler(self._global_interval_s)
+
     def stop_mass_tests(self) -> None:
         """Detiene los ciclos de testeos."""
         self.mass_tests_enabled = False
@@ -145,6 +179,55 @@ class Supervisor:
             except Exception:
                 pass
             self.hub = None
+
+    # ------------------------------------------------------------------
+    # Global analysis scheduler
+    def start_global_scheduler(self, interval_s: int) -> None:
+        """Inicia el scheduler periódico de análisis global."""
+        self._global_interval_s = int(interval_s)
+        if self._global_thread and self._global_thread.is_alive():
+            return
+        self._global_stop = threading.Event()
+        self._global_thread = threading.Thread(
+            target=self._global_loop, daemon=True
+        )
+        self._global_thread.start()
+
+    def stop_global_scheduler(self) -> None:
+        """Detiene el scheduler de análisis global."""
+        if self._global_stop:
+            self._global_stop.set()
+        if self._global_thread:
+            self._global_thread.join(timeout=1)
+            self._global_thread = None
+
+    def _global_loop(self) -> None:
+        while self._global_stop and not self._global_stop.is_set():
+            time.sleep(self._global_interval_s)
+            if self._global_stop and self._global_stop.is_set():
+                break
+            try:
+                self.run_global_analysis()
+            except Exception as e:
+                self._emit("ERROR", "llm", None, None, "global_analysis_fail", {"error": str(e)})
+
+    def run_global_analysis(self) -> None:
+        summary = self.storage.gather_global_summary()
+        self._emit("INFO", "llm", None, None, "global_summary", summary)
+        insights = self.llm.analyze_global(summary)
+        self._emit("INFO", "llm", None, None, "global_insights", insights)
+
+        # Persist report to disk
+        ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        reports_dir = Path("reports")
+        reports_dir.mkdir(exist_ok=True)
+        with open(reports_dir / f"global_insights_{ts}.json", "w", encoding="utf-8") as fh:
+            json.dump({"summary": summary, "insights": insights}, fh, ensure_ascii=False, indent=2)
+
+        # Generate optional patch in dry-run mode
+        diff = self.llm.propose_patch(insights)
+        if diff:
+            self._emit("INFO", "llm", None, None, "global_patch", {"diff": diff})
 
     # ------------------------------------------------------------------
     def _loop(self) -> None:
@@ -166,7 +249,9 @@ class Supervisor:
                 "INFO", "llm", cycle, None, "llm_request", {"summary": cycle_summary}
             )
             try:
-                decision = self.llm.analyze_cycle_and_pick_winner(cycle_summary)
+                decision = self.llm.analyze_cycle_and_pick_winner(
+                    cycle_summary, self.state.metric_weights
+                )
                 self._emit("INFO", "llm", cycle, None, "llm_response", decision)
 
                 winner_id = int(decision.get("winner_bot_id", -1))
@@ -179,8 +264,14 @@ class Supervisor:
                     "ERROR", "llm", cycle, None, "llm_error", {"error": str(exc)}
                 )
                 try:
-                    winner_id, winner_cfg = self.pick_winner(cycle)
-                    winner_reason = "max_pnl"
+                    fallback = self.llm.pick_winner_local(
+                        cycle_summary, self.state.metric_weights
+                    )
+                    winner_id = int(fallback.get("winner_bot_id", -1))
+                    winner_reason = str(fallback.get("reason", "weighted_score"))
+                    winner_cfg = self.storage.get_bot(winner_id)
+                    if winner_cfg is None:
+                        raise ValueError("winner cfg not found")
                 except ValueError as err:
                     self._emit(
                         "ERROR",
@@ -276,12 +367,18 @@ class Supervisor:
 
             self._current_generation = []
             for i in range(self._num_bots):
-                var = variations[i] if i < len(variations) else {"name": f"Bot-{self._next_bot_id + i}", "mutations": {}}
+                var = (
+                    variations[i]
+                    if i < len(variations)
+                    else {"name": f"Bot-{self._next_bot_id + i}", "mutations": {}}
+                )
+                muts = var.get("mutations", {}) or {}
+                muts["order_size_usd"] = self._order_size_usd
                 cfg = BotConfig(
                     id=self._next_bot_id + i,
                     cycle=cycle,
                     name=str(var.get("name", f"Bot-{self._next_bot_id + i}")),
-                    mutations=var.get("mutations", {}),
+                    mutations=muts,
                     seed_parent=None,
                 )
                 self.storage.save_bot(cfg)
@@ -291,6 +388,9 @@ class Supervisor:
             # actualizar ciclo en configs existentes
             for cfg in self._current_generation:
                 cfg.cycle = cycle
+                muts = cfg.mutations or {}
+                muts["order_size_usd"] = self._order_size_usd
+                cfg.mutations = muts
                 self.storage.save_bot(cfg)
 
         self._emit("INFO", "cycle", cycle, None, "cycle_start", {})

--- a/state/app_state.py
+++ b/state/app_state.py
@@ -20,6 +20,18 @@ class AppState:
     apis_verified: Dict[str, bool] = field(
         default_factory=lambda: {"binance": False, "llm": False}
     )
+    metric_weights: Dict[str, float] = field(
+        default_factory=lambda: {
+            "pnl": 0.35,
+            "timeouts": 0.25,
+            "slippage": 0.2,
+            "win_rate": 0.1,
+            "avg_hold_s": 0.06,
+            "cancel_replace_count": 0.04,
+        }
+    )
+    order_size_usd: float = 50.0
+    order_size_mode: str = "Fijo"
     _file: str = field(init=False, repr=False)
 
     def __post_init__(self) -> None:

--- a/tests/test_global_analysis.py
+++ b/tests/test_global_analysis.py
@@ -1,0 +1,22 @@
+import os
+import time
+
+from orchestrator.supervisor import Supervisor
+from orchestrator.storage import SQLiteStorage
+from llm.client import LLMClient
+
+
+def test_global_scheduler_runs_twice(tmp_path):
+    db = tmp_path / "titan.db"
+    storage = SQLiteStorage(str(db))
+    llm = LLMClient()  # sin API key -> usa fallback determinista
+    sup = Supervisor(storage=storage, llm_client=llm)
+    events = []
+    sup.stream_events(events.append)
+
+    sup.start_global_scheduler(interval_s=1)
+    time.sleep(2.5)
+    sup.stop_global_scheduler()
+
+    runs = [e for e in events if e.message == "global_insights"]
+    assert len(runs) >= 2

--- a/tests/test_min_notional.py
+++ b/tests/test_min_notional.py
@@ -1,0 +1,41 @@
+import asyncio
+import time
+from engine.strategy_base import StrategyBase
+from engine.strategy_params import Params
+from exchange_utils.exchange_meta import exchange_meta
+
+
+class DummyExchange:
+    async def get_market(self, symbol):
+        return {"price_increment": 0.1, "quote": "USDT"}
+
+    async def get_markets(self):
+        return {"ETHUSDT": {"price_increment": 0.1, "maker": 0.001, "taker": 0.001}}
+
+    async def get_ticker(self, sym):
+        return {"last": 100.0}
+
+    def _quote_to_usd(self, q):
+        return 1.0
+
+
+async def _run_test():
+    filters = {"priceIncrement": 0.1, "stepSize": 0.01, "minNotional": 10}
+    orig = exchange_meta.get_symbol_filters
+    exchange_meta.get_symbol_filters = lambda s: filters
+    try:
+        ex = DummyExchange()
+        strat = StrategyBase(ex)
+        params = Params(order_size_usd=5.0, min_notional_margin=1.0)
+        book = {"bids": [(99, 1)], "asks": [(100, 1)], "ts": time.time()}
+        data = await strat.analyze_book(params, "ETHUSDT", book)
+    finally:
+        exchange_meta.get_symbol_filters = orig
+    return data
+
+
+def test_analyze_book_enforces_min_notional():
+    data = asyncio.run(_run_test())
+    assert data is not None
+    # amount should correspond to (minNotional + margin) / price = (10 + 1) / 100
+    assert abs(data["amount"] - 0.11) < 1e-6

--- a/tests/test_order_size.py
+++ b/tests/test_order_size.py
@@ -1,0 +1,55 @@
+import asyncio
+import time
+from orchestrator.supervisor import Supervisor
+from orchestrator.models import BotConfig
+from orchestrator.storage import SQLiteStorage
+from engine.strategy_base import StrategyBase
+from engine.strategy_params import map_mutations_to_params
+
+
+class DummyExchange:
+    async def get_market(self, symbol):
+        return {"price_increment": 0.1, "quote": "USDT"}
+
+    async def get_markets(self):  # pragma: no cover
+        return {"ETHUSDT": {"price_increment": 0.1}}
+
+    async def get_ticker(self, sym):  # pragma: no cover
+        return {"last": 100.0}
+
+    def _quote_to_usd(self, q):
+        return 1.0
+
+
+async def _place_one(storage, cfg, size, oid):
+    sup = Supervisor(storage=storage)
+    sup._current_generation = [cfg]
+    sup.set_order_size_usd(size)
+    params = map_mutations_to_params(cfg.mutations)
+    strat = StrategyBase(DummyExchange())
+    book = {"bids": [(99, 1)], "asks": [(100, 1)], "ts": time.time()}
+    data = await strat.analyze_book(params, "ETHUSDT", book)
+    storage.save_order(
+        {
+            "order_id": f"{cfg.id}-{oid}",
+            "bot_id": cfg.id,
+            "cycle_id": cfg.cycle,
+            "symbol": "ETHUSDT",
+            "side": "buy",
+            "qty": data["amount"],
+            "price": data["price"],
+        }
+    )
+
+
+def test_order_size_persists(tmp_path):
+    db = tmp_path / "t.db"
+    storage = SQLiteStorage(db_path=str(db))
+    cfg = BotConfig(id=1, cycle=1, name="bot", mutations={}, seed_parent=None)
+    asyncio.run(_place_one(storage, cfg, 10.0, 1))
+    asyncio.run(_place_one(storage, cfg, 25.0, 2))
+    rows = storage.iter_orders(1, 1)
+    assert len(rows) == 2
+    notionals = [r["price"] * r["qty"] for r in rows]
+    assert abs(notionals[0] - 10.0) < 1e-6
+    assert abs(notionals[1] - 25.0) < 1e-6

--- a/ui_app.py
+++ b/ui_app.py
@@ -12,6 +12,7 @@ from llm import LLMClient as MassLLMClient
 from components.testeos_frame import TesteosFrame
 from components.auth_frame import AuthFrame
 from components.info_frame import InfoFrame, clean_text
+from components.settings_frame import SettingsFrame
 
 from state.app_state import AppState as MassTestState
 from orchestrator.supervisor import Supervisor
@@ -108,6 +109,8 @@ class App(tb.Window):
         self._build_ui()
         # Instanciar LLM y supervisor después de construir UI para cablear logs
         llm_client = MassLLMClient(on_log=self.info_frame.append_llm_log)
+        # guardar referencia para futuras consultas (meta-ganador, etc.)
+        self.llm_client = llm_client
         self._supervisor = Supervisor(
             app_state=self.mass_state,
             llm_client=llm_client,
@@ -161,15 +164,20 @@ class App(tb.Window):
         self.lbl_pnl.grid(row=1, column=2, sticky="e", padx=5)
         self.lbl_bal.grid(row=1, column=3, sticky="e", padx=5)
 
-        # Pestañas principales
-        self.notebook = ttk.Notebook(self)
-        self.notebook.grid(row=1, column=0, columnspan=2, sticky="nsew", padx=(10,10), pady=(0,8))
+        # Panel fijo para testeos masivos
         self.testeos_frame = TesteosFrame(
-            self.notebook,
+            self,
             self.on_toggle_mass_tests,
             self.on_load_winner_for_sim,
         )
-        self.notebook.add(self.testeos_frame, text="Testeos Masivos")
+        self.testeos_frame.grid(
+            row=1,
+            column=0,
+            columnspan=2,
+            sticky="nsew",
+            padx=(10, 10),
+            pady=(0, 8),
+        )
 
         # Panel inferior izquierdo para órdenes
         left = ttk.Frame(self, padding=(10,0,10,10))
@@ -223,29 +231,20 @@ class App(tb.Window):
 
         ttk.Label(right, text="Ajustes").grid(row=0, column=0, sticky="w", pady=(0,6))
 
-        # Tamaños + toggle mínimo + apply
-        frm_size = ttk.Labelframe(right, text="Tamaño por operación (USD)", padding=8)
-        frm_size.grid(row=1, column=0, sticky="ew", pady=6)
-        frm_size.columnconfigure(1, weight=1)
-        self.var_size_sim = tb.DoubleVar(value=self.cfg.size_usd_sim)
-        self.var_size_live = tb.DoubleVar(value=self.cfg.size_usd_live)
-        self.var_use_min_bin = tb.BooleanVar(value=False)
-        ttk.Label(frm_size, text="SIM").grid(row=0, column=0, sticky="w")
-        self.ent_size_sim = ttk.Entry(frm_size, textvariable=self.var_size_sim, width=14)
-        self.ent_size_sim.grid(row=0, column=1, sticky="ew")
-        ttk.Label(frm_size, text="LIVE").grid(row=1, column=0, sticky="w")
-        self.ent_size_live = ttk.Entry(frm_size, textvariable=self.var_size_live, width=14)
-        self.ent_size_live.grid(row=1, column=1, sticky="ew")
-        ttk.Button(frm_size, text="Aplicar tamaño", command=self._apply_sizes).grid(row=0, column=2, rowspan=2, padx=6)
-        self.lbl_min_marker = ttk.Label(frm_size, text="Mínimo Binance: --")
-        self.lbl_min_marker.grid(row=2, column=0, columnspan=2, sticky="w", pady=(4,0))
-        ttk.Checkbutton(
-            frm_size,
-            text="Min Binance",
-            variable=self.var_use_min_bin,
-            style="info.Switch",
-            command=self._toggle_min_binance,
-        ).grid(row=2, column=2, padx=6, pady=(4,0))
+        # Tamaños + toggle mínimo + apply (SettingsFrame)
+        self.settings_frame = SettingsFrame(
+            right,
+            self._apply_sizes,
+            self._toggle_min_binance,
+            self.cfg,
+        )
+        self.settings_frame.grid(row=1, column=0, sticky="ew", pady=6)
+        self.var_size_sim = self.settings_frame.var_size_sim
+        self.var_size_live = self.settings_frame.var_size_live
+        self.var_use_min_bin = self.settings_frame.var_use_min_bin
+        self.ent_size_sim = self.settings_frame.ent_size_sim
+        self.ent_size_live = self.settings_frame.ent_size_live
+        self.lbl_min_marker = self.settings_frame.lbl_min_marker
 
         # API keys and verification badges
         self.auth_frame = AuthFrame(right, self._start_confirm_apis)
@@ -289,6 +288,7 @@ class App(tb.Window):
             self._apply_min_orders,
             self._revert_patch,
             self._apply_winner_live,
+            self._submit_patch,
         )
         self.info_frame.grid(row=5, column=0, sticky="nsew", pady=(6, 0))
 
@@ -464,6 +464,10 @@ class App(tb.Window):
             except Exception:
                 pass
 
+    def _submit_patch(self):
+        """Placeholder to submit the last LLM patch as a PR."""
+        self.log_append("[LLM] Solicitud de PR enviada (dummy)")
+
     def _apply_winner_live(self):
         self.log_append("[TEST] Aplicar ganador a LIVE presionado")
 
@@ -471,14 +475,38 @@ class App(tb.Window):
     def _apply_sizes(self):
 
         """Aplica los tamaños por operación para SIM y LIVE."""
+        margin = 1.0
+        min_usd = 0.0
         try:
-            if self._engine_sim:
-                self._engine_sim.cfg.size_usd_sim = float(self.var_size_sim.get())
+            self._ensure_exchange()
+            min_usd = self.exchange.global_min_notional_usd()
         except Exception:
             pass
+        # SIM size
         try:
+            size_sim = float(self.var_size_sim.get())
+            eff_sim = max(size_sim, min_usd + margin)
+            if eff_sim != size_sim:
+                self.var_size_sim.set(eff_sim)
+                self.log_append(
+                    f"[ENGINE] Tamaño SIM ajustado a {eff_sim:.2f} USD (mínimo {min_usd:.2f})"
+                )
+            if self._engine_sim:
+                self._engine_sim.cfg.size_usd_sim = eff_sim
+        except Exception:
+            pass
+        # LIVE size
+        try:
+            size_live = float(self.var_size_live.get())
+            eff_live = max(size_live, min_usd + margin)
+            if eff_live != size_live:
+                self.var_size_live.set(eff_live)
+                self.log_append(
+                    f"[ENGINE] Tamaño LIVE ajustado a {eff_live:.2f} USD (mínimo {min_usd:.2f})"
+                )
             if self._engine_live:
-                self._engine_live.cfg.size_usd_live = float(self.var_size_live.get())
+                self._engine_live.cfg.size_usd_live = eff_live
+            self._supervisor.set_order_size_usd(eff_live)
         except Exception:
             pass
 
@@ -488,7 +516,8 @@ class App(tb.Window):
         if use_min:
             try:
                 self._ensure_exchange()
-                min_usd = self.exchange.global_min_notional_usd()
+                margin = 1.0
+                min_usd = self.exchange.global_min_notional_usd() + margin
                 self.var_size_live.set(min_usd)
                 self.ent_size_live.configure(state="disabled")
                 self.lbl_min_marker.configure(text=f"Mínimo Binance: {min_usd:.2f} USDT")
@@ -498,6 +527,7 @@ class App(tb.Window):
                 self.lbl_min_marker.configure(text="Mínimo Binance: --")
         else:
             self.ent_size_live.configure(state="normal")
+        self._apply_sizes()
 
     def _apply_min_orders(self):
         """Aplica el mínimo de órdenes requerido para la sesión de test."""
@@ -534,20 +564,48 @@ class App(tb.Window):
             self._supervisor.stop_mass_tests()
 
     def on_load_winner_for_sim(self) -> None:
-        """Carga la configuración ganadora en el bot SIM."""
-        if not self._winner_cfg:
-            self.log_append("[TEST] No hay ganador disponible")
+        """Selecciona meta-ganador histórico y lo carga en el bot SIM."""
+        try:
+            winners = self._supervisor.storage.list_winners()
+        except Exception:
+            winners = []
+
+        if not winners:
+            self.log_append("[TEST] No hay ganadores históricos")
             return
+
+        # Pedir al LLM que elija el meta-ganador
+        try:
+            res = self.llm_client.pick_meta_winner(winners)
+            bot_id = res.get("bot_id")
+            reason = res.get("reason", "")
+        except Exception:
+            bot_id = None
+            reason = ""
+
+        if bot_id is None:
+            self.log_append("[TEST] No se pudo determinar meta-ganador")
+            return
+
+        cfg = self._supervisor.storage.get_bot(int(bot_id))
+        if not cfg:
+            self.log_append("[TEST] Configuración del ganador no encontrada")
+            return
+
+        # Guardar para posible uso posterior (aplicar a LIVE)
+        self._winner_cfg = cfg
+
         try:
             if self._engine_sim and self._engine_sim.is_alive():
                 self._engine_sim.stop()
-            self._engine_sim = load_sim_config(self._winner_cfg.mutations)
+            self._engine_sim = load_sim_config(cfg.mutations)
             self._engine_sim.start()
             self.var_bot_sim.set(True)
             self.lbl_state_sim.configure(text="SIM: ON", bootstyle=SUCCESS)
-            self.log_append("[TEST] Bot ganador cargado en modo SIM")
+            self.info_frame.append_llm_log("meta_winner", {"bot_id": bot_id, "reason": reason})
+            self.log_append("[TEST] Bot meta-ganador cargado en modo SIM")
         except Exception as exc:
-            self.log_append(f"[TEST] Error al cargar ganador: {exc}")
+            self.log_append(f"[TEST] Error al cargar meta-ganador: {exc}")
 
     # ------------------- Log helpers -------------------
     def log_append(self, msg: str):
@@ -612,6 +670,12 @@ class App(tb.Window):
                     info = ev.payload
                     info["cycle"] = ev.cycle
                     self.testeos_frame.add_cycle_history(info)
+                elif ev.message == "global_insights" and ev.payload:
+                    self.info_frame.append_llm_log("global_insights", ev.payload)
+                elif ev.message == "global_patch" and ev.payload:
+                    self.info_frame.append_llm_log(
+                        "global_patch", ev.payload.get("diff", "")
+                    )
 
         except queue.Empty:
             pass


### PR DESCRIPTION
## Summary
- collect global trading metrics and schedule periodic LLM analysis with optional patch proposal
- expose analysis insights and patch option in the information panel
- support gathering aggregate metrics from storage and added tests for scheduler reliability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1c85dafa083289a346f6707f33357