### PR TITLE
Color order rows by side and mode

### DIFF
--- a/ui_styles.py
+++ b/ui_styles.py
@@ -1,0 +1,9 @@
+from tkinter import ttk
+
+
+def apply_order_tags(tree: ttk.Treeview) -> None:
+    """Configure Treeview tags for order side and mode."""
+    tree.tag_configure("side_buy", foreground="#00A000")
+    tree.tag_configure("side_sell", foreground="#D00000")
+    tree.tag_configure("mode_sim", background="#DDEBFF")
+    tree.tag_configure("mode_live", background="")


### PR DESCRIPTION
## Summary
- remove side/mode columns from order tables
- add Treeview row tags for side and mode styling
- centralize tag setup in `ui_styles.apply_order_tags`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1da3d5c6883289e7d3e8633e83d47