### PR TITLE
feat: uniform timestamp formatting

### DIFF
--- a/components/orders_closed_frame.py
+++ b/components/orders_closed_frame.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict, List
+import tkinter as tk
+from tkinter import ttk
+from ttkbootstrap.constants import *
+
+from utils.timefmt import fmt_ts
+
+
+class OrdersClosedFrame(ttk.Frame):
+    """Frame que muestra las órdenes cerradas."""
+
+    def __init__(self, parent: ttk.Widget) -> None:
+        super().__init__(parent, padding=10)
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        cols = ("fecha", "symbol", "price", "qty_usd")
+        self.tree = ttk.Treeview(self, columns=cols, show="headings", height=10)
+        headings = [
+            ("fecha", "Fecha", 150),
+            ("symbol", "Par", 80),
+            ("price", "Precio", 100),
+            ("qty_usd", "USD", 100),
+        ]
+        for col, txt, width in headings:
+            self.tree.heading(col, text=txt)
+            self.tree.column(col, width=width, anchor="center", stretch=True)
+        vsb = ttk.Scrollbar(self, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=vsb.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+
+    def refresh(self, orders: List[Dict[str, Any]]) -> None:
+        """Refresca el listado de órdenes cerradas."""
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        for o in orders:
+            self.tree.insert(
+                "",
+                "end",
+                values=(
+                    fmt_ts(o.get("ts")),
+                    o.get("symbol", ""),
+                    f"{o.get('price', 0.0):.8f}",
+                    f"{o.get('qty_usd', 0.0):.2f}",
+                ),
+            )

--- a/components/orders_open_frame.py
+++ b/components/orders_open_frame.py
@@ -1,0 +1,49 @@
+from typing import Any, Dict, List
+import tkinter as tk
+from tkinter import ttk
+from ttkbootstrap.constants import *
+
+from utils.timefmt import fmt_ts
+
+
+class OrdersOpenFrame(ttk.Frame):
+    """Frame que muestra las órdenes abiertas."""
+
+    def __init__(self, parent: ttk.Widget) -> None:
+        super().__init__(parent, padding=10)
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        cols = ("id", "symbol", "price", "qty_usd", "fecha")
+        self.tree = ttk.Treeview(self, columns=cols, show="headings", height=10)
+        headings = [
+            ("id", "ID", 80),
+            ("symbol", "Par", 80),
+            ("price", "Precio", 100),
+            ("qty_usd", "USD", 100),
+            ("fecha", "Fecha", 150),
+        ]
+        for col, txt, width in headings:
+            self.tree.heading(col, text=txt)
+            self.tree.column(col, width=width, anchor="center", stretch=True)
+        vsb = ttk.Scrollbar(self, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=vsb.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+
+    def refresh(self, orders: List[Dict[str, Any]]) -> None:
+        """Refresca el listado de órdenes abiertas."""
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        for o in orders:
+            self.tree.insert(
+                "",
+                "end",
+                values=(
+                    o.get("id", ""),
+                    o.get("symbol", ""),
+                    f"{o.get('price', 0.0):.8f}",
+                    f"{o.get('qty_usd', 0.0):.2f}",
+                    fmt_ts(o.get("ts")),
+                ),
+            )

--- a/tests/test_timefmt.py
+++ b/tests/test_timefmt.py
@@ -1,0 +1,14 @@
+from utils.timefmt import fmt_ts
+
+
+def test_fmt_ts_seconds():
+    # 2024-01-15 12:34:56 UTC -> 2024-01-15 13:34:56 Europe/Madrid
+    assert fmt_ts(1705322096) == "2024-01-15 13:34:56"
+
+
+def test_fmt_ts_milliseconds():
+    assert fmt_ts(1705322096000) == "2024-01-15 13:34:56"
+
+
+def test_fmt_ts_iso():
+    assert fmt_ts("2024-07-15T15:20:30Z") == "2024-07-15 17:20:30"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utility package

--- a/utils/timefmt.py
+++ b/utils/timefmt.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Time formatting helpers."""
+
+from datetime import datetime
+from typing import Any, Union
+from zoneinfo import ZoneInfo
+
+__all__ = ["fmt_ts"]
+
+
+_MIN_VALID_MS = 946684800000  # 2000-01-01 00:00:00 UTC
+
+
+def _to_datetime(ts: Any, tz: ZoneInfo) -> datetime | None:
+    """Convert ``ts`` to a timezone-aware ``datetime``.
+
+    Supported inputs:
+    - seconds or milliseconds since epoch (``int``/``float`` or numeric ``str``)
+    - ISO 8601 strings (with optional timezone).
+    """
+    if ts is None:
+        return None
+
+    # Allow strings that may contain numeric values
+    if isinstance(ts, str):
+        ts = ts.strip()
+        if not ts:
+            return None
+        # Numeric string
+        try:
+            ts_num = float(ts)
+            ts = ts_num
+        except ValueError:
+            # ISO format
+            try:
+                dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=tz)
+            else:
+                dt = dt.astimezone(tz)
+            return dt
+
+    if isinstance(ts, (int, float)):
+        # Determine if ts is in milliseconds
+        ts_ms = float(ts)
+        if ts_ms > 1e12:  # assume milliseconds
+            ts_ms = ts_ms
+        else:
+            ts_ms = ts_ms * 1000
+        if ts_ms < _MIN_VALID_MS:
+            return None
+        try:
+            return datetime.fromtimestamp(ts_ms / 1000, tz)
+        except Exception:
+            return None
+
+    return None
+
+
+def fmt_ts(ts: Any, tz: str = "Europe/Madrid") -> str:
+    """Format various timestamp inputs as ``YYYY-MM-DD HH:MM:SS``.
+
+    Parameters
+    ----------
+    ts:
+        Timestamp in seconds, milliseconds or ISO-8601 string.
+    tz:
+        Target timezone. Defaults to ``Europe/Madrid``.
+    """
+    zone = ZoneInfo(tz)
+    dt = _to_datetime(ts, zone)
+    if dt is None:
+        return "—"
+    return dt.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Summary
- add timestamp formatting helper using zoneinfo
- display formatted date in open and closed order tables
- test formatting for second, millisecond and ISO inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1dd1bf4a483288956b2a172b74f36