### PR TITLE
Format LLM logs and restore log controls

### DIFF
--- a/components/info_frame.py
+++ b/components/info_frame.py
@@ -1,7 +1,7 @@
 import queue
 import re
 import tkinter as tk
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from ttkbootstrap.constants import *
 from ttkbootstrap.scrolled import ScrolledText
@@ -12,6 +12,15 @@ def clean_text(payload: Any) -> str:
     text = str(payload)
     text = re.sub(r"\b[a-fA-F0-9]{64}\b", "", text)
     return text.translate(str.maketrans("", "", "{}[]\"'"))
+
+
+def sanitize_log(text: str) -> str:
+    """Reduce sequences of commas and empty lists for cleaner logs."""
+    # collapse repeating commas/spaces like ", , ," -> ", "
+    text = re.sub(r"(\s*,\s*){3,}", ", ", text)
+    # remove repeated empty lists "[], [], []" -> "[]"
+    text = re.sub(r"(?:\[\s*\]\s*,\s*){2,}\[\s*\]", "[]", text)
+    return text
 
 class InfoFrame(ttk.Labelframe):
     """Frame que muestra información y logs del LLM."""
@@ -30,42 +39,84 @@ class InfoFrame(ttk.Labelframe):
         self.columnconfigure(1, weight=1)
         self.rowconfigure(0, weight=1)
 
-        self._log_queue: "queue.Queue[str]" = queue.Queue()
+        self._log_queue: "queue.Queue[Callable[[], None]]" = queue.Queue()
+        self.paused = False
 
         self.txt_logs = ScrolledText(self, height=6, autohide=True, wrap="word")
         self.txt_logs.grid(row=0, column=0, columnspan=2, sticky="nsew")
 
-        ttk.Label(self, text="Órdenes mínimas").grid(row=1, column=0, sticky="w")
-        ttk.Entry(self, textvariable=var_min_orders, width=10).grid(row=1, column=1, sticky="e")
+        ttk.Button(self, text="Limpiar log", command=self.clear_logs).grid(
+            row=1, column=0, sticky="ew", pady=(4, 0)
+        )
+        self.btn_pause = ttk.Button(self, text="Pausar log", command=self.toggle_pause)
+        self.btn_pause.grid(row=1, column=1, sticky="ew", pady=(4, 0))
+
+        ttk.Label(self, text="Órdenes mínimas").grid(row=2, column=0, sticky="w")
+        ttk.Entry(self, textvariable=var_min_orders, width=10).grid(row=2, column=1, sticky="e")
         ttk.Button(
             self,
             text="Aplicar mín. órdenes",
             command=on_apply_min_orders,
-        ).grid(row=2, column=0, columnspan=2, sticky="ew", pady=(4, 0))
+        ).grid(row=3, column=0, columnspan=2, sticky="ew", pady=(4, 0))
         ttk.Button(self, text="Revertir patch", command=on_revert_patch).grid(
-            row=3, column=0, sticky="ew", pady=(4, 0)
+            row=4, column=0, sticky="ew", pady=(4, 0)
         )
         ttk.Button(self, text="Aplicar a LIVE", command=on_apply_winner_live).grid(
-            row=3, column=1, sticky="ew", pady=(4, 0)
+            row=4, column=1, sticky="ew", pady=(4, 0)
         )
         ttk.Button(self, text="Crear PR patch", command=on_submit_patch).grid(
-            row=4, column=0, columnspan=2, sticky="ew", pady=(4, 0)
+            row=5, column=0, columnspan=2, sticky="ew", pady=(4, 0)
         )
 
         self.after(200, self._process_log_queue)
 
     # ------------------------------------------------------------------
-    def append_llm_log(self, tag: str, payload: Any) -> None:
+    def append_llm_log(
+        self, tag: str, payload: Any, label: Optional[str] = None
+    ) -> None:
         """Encola eventos del LLM para mostrarlos."""
-        text = clean_text(payload)
-        self._log_queue.put(f"[LLM {tag}] {text}")
+        text = sanitize_log(clean_text(payload))
+        if tag == "request":
+            self._log_queue.put(
+                lambda: self.render_llm_request(text, label)
+            )
+        elif tag == "response":
+            self._log_queue.put(lambda: self.render_llm_response(text))
+        else:
+            self._log_queue.put(
+                lambda: self._insert_text(f"[LLM {tag}] {text}")
+            )
+
+    def render_llm_request(self, text: str, label: Optional[str]) -> None:
+        msg = f'Envío LLM: Prompt "{label}"' if label else f"Envío LLM: {text}"
+        self._insert_text(msg)
+
+    def render_llm_response(self, text: str) -> None:
+        self._insert_text(f"Respuesta LLM: {text}")
+
+    def _insert_text(self, line: str) -> None:
+        self.txt_logs.insert("end", line + "\n")
+        self.txt_logs.see("end")
+
+    def clear_logs(self) -> None:
+        """Borra el contenido visible y la cola."""
+        self.txt_logs.delete("1.0", "end")
+        with self._log_queue.mutex:
+            self._log_queue.queue.clear()
+
+    def toggle_pause(self) -> None:
+        """Alterna el estado de pausa de los logs."""
+        self.paused = not self.paused
+        self.btn_pause.configure(
+            text="Reanudar log" if self.paused else "Pausar log"
+        )
 
     def _process_log_queue(self) -> None:
-        try:
-            while True:
-                line = self._log_queue.get_nowait()
-                self.txt_logs.insert("end", line + "\n")
-                self.txt_logs.see("end")
-        except queue.Empty:
-            pass
+        if not self.paused:
+            try:
+                while True:
+                    func = self._log_queue.get_nowait()
+                    func()
+            except queue.Empty:
+                pass
         self.after(200, self._process_log_queue)

--- a/llm/client.py
+++ b/llm/client.py
@@ -97,10 +97,10 @@ class LLMClient:
             return False
 
     # ------------------------------------------------------------------
-    def _log(self, tag: str, payload: Any) -> None:
+    def _log(self, tag: str, payload: Any, label: Optional[str] = None) -> None:
         if self.on_log:
             try:
-                self.on_log(tag, payload)
+                self.on_log(tag, payload, label)
             except Exception:
                 pass
 
@@ -136,14 +136,18 @@ class LLMClient:
         return None
 
     # ------------------------------------------------------------------
-    def _call_openai(self, trading_spec_text: str) -> List[Dict[str, object]]:
+    def _call_openai(
+        self, trading_spec_text: str, label: Optional[str] = None
+    ) -> List[Dict[str, object]]:
         assert self._client is not None
         messages = [
             {"role": "system", "content": PROMPT_P0},
             {"role": "system", "content": PROMPT_INICIAL_VARIACIONES},
             {"role": "user", "content": trading_spec_text},
         ]
-        self._log("request", {"model": self.model, "messages": messages})
+        self._log(
+            "request", {"model": self.model, "messages": messages}, label
+        )
         try:
             resp = self._client.chat.completions.create(
                 model=self.model,
@@ -199,7 +203,9 @@ class LLMClient:
         raw: List[Dict[str, object]] = []
         if self._client is not None and self.check_credentials():
             try:
-                raw = self._call_openai(trading_spec_text)
+                raw = self._call_openai(
+                    trading_spec_text, label="Variaciones Iniciales"
+                )
             except Exception:
                 raw = []
         if not raw:
@@ -297,7 +303,9 @@ class LLMClient:
                     "content": json.dumps({"history_fingerprints": history_fingerprints}),
                 },
             ]
-            self._log("request", {"model": self.model, "messages": messages})
+            self._log(
+                "request", {"model": self.model, "messages": messages}, label="Nueva Generación"
+            )
             try:
                 resp = self._client.chat.completions.create(
                     model=self.model,
@@ -364,7 +372,9 @@ class LLMClient:
                 {"role": "system", "content": PROMPT_ANALISIS_CICLO},
                 {"role": "user", "content": json.dumps(cycle_summary)},
             ]
-            self._log("request", {"model": self.model, "messages": messages})
+            self._log(
+                "request", {"model": self.model, "messages": messages}, label="Análisis de Ciclo"
+            )
             try:
                 resp = self._client.chat.completions.create(
                     model=self.model,
@@ -394,7 +404,9 @@ class LLMClient:
                 {"role": "system", "content": PROMPT_META_GANADOR},
                 {"role": "user", "content": json.dumps(winners)},
             ]
-            self._log("request", {"model": self.model, "messages": messages})
+            self._log(
+                "request", {"model": self.model, "messages": messages}, label="Meta-ganador"
+            )
             try:
                 resp = self._client.chat.completions.create(
                     model=self.model,
@@ -542,7 +554,9 @@ class LLMClient:
                 {"role": "system", "content": PROMPT_ANALISIS_GLOBAL},
                 {"role": "user", "content": json.dumps(summary)},
             ]
-            self._log("request", {"model": self.model, "messages": messages})
+            self._log(
+                "request", {"model": self.model, "messages": messages}, label="Análisis Global"
+            )
             try:
                 resp = self._client.chat.completions.create(
                     model=self.model,

--- a/tests/test_info_frame.py
+++ b/tests/test_info_frame.py
@@ -1,0 +1,47 @@
+import tkinter as tk
+
+from components.info_frame import InfoFrame
+
+
+def _dummy():
+    pass
+
+
+def test_logging_and_controls():
+    root = tk.Tk()
+    root.withdraw()
+
+    var = tk.IntVar()
+    frame = InfoFrame(root, var, _dummy, _dummy, _dummy, _dummy)
+
+    frame.append_llm_log(
+        "request", "hola,,, , ,", label="Variaciones Iniciales"
+    )
+    frame.append_llm_log(
+        "response", "respuesta,,, , , [], [], []"
+    )
+    frame.append_llm_log("request", "adhoc,,, , ,", label=None)
+    frame._process_log_queue()
+
+    text = frame.txt_logs.get("1.0", "end")
+    assert 'Envío LLM: Prompt "Variaciones Iniciales"' in text
+    assert 'Respuesta LLM:' in text
+    assert ', , ,' not in text
+    assert '[], [], []' not in text
+    assert 'Envío LLM: adhoc' in text
+
+    frame.toggle_pause()
+    frame.append_llm_log("response", "otra")
+    frame._process_log_queue()
+    assert text == frame.txt_logs.get("1.0", "end")
+
+    frame.toggle_pause()
+    frame.append_llm_log("response", "nuevo")
+    frame._process_log_queue()
+    assert 'nuevo' in frame.txt_logs.get("1.0", "end")
+
+    frame.clear_logs()
+    assert frame.txt_logs.get("1.0", "end").strip() == ""
+
+    root.destroy()
+


### PR DESCRIPTION
## Summary
- sanitize and format LLM log entries with request/response helpers
- pass prompt labels from LLM client for clearer logging
- add Clear/Pause log buttons and tests for log formatting

## Testing
- `xvfb-run -a pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1e0d450bc83289df7f1f6e4c7ba1c