### PR TITLE
Format LLM logs, restore log controls, and ensure mass test panel visibility

### DIFF
--- a/components/info_frame.py
+++ b/components/info_frame.py
@@ -1,7 +1,7 @@
 import queue
 import re
 import tkinter as tk
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from ttkbootstrap.constants import *
 from ttkbootstrap.scrolled import ScrolledText
@@ -12,6 +12,15 @@ def clean_text(payload: Any) -> str:
     text = str(payload)
     text = re.sub(r"\b[a-fA-F0-9]{64}\b", "", text)
     return text.translate(str.maketrans("", "", "{}[]\"'"))
+
+
+def sanitize_log(text: str) -> str:
+    """Reduce sequences of commas and empty lists for cleaner logs."""
+    # collapse repeating commas/spaces like ", , ," -> ", "
+    text = re.sub(r"(\s*,\s*){3,}", ", ", text)
+    # remove repeated empty lists "[], [], []" -> "[]"
+    text = re.sub(r"(?:\[\s*\]\s*,\s*){2,}\[\s*\]", "[]", text)
+    return text
 
 class InfoFrame(ttk.Labelframe):
     """Frame que muestra información y logs del LLM."""
@@ -30,42 +39,84 @@ class InfoFrame(ttk.Labelframe):
         self.columnconfigure(1, weight=1)
         self.rowconfigure(0, weight=1)
 
-        self._log_queue: "queue.Queue[str]" = queue.Queue()
+        self._log_queue: "queue.Queue[Callable[[], None]]" = queue.Queue()
+        self.paused = False
 
         self.txt_logs = ScrolledText(self, height=6, autohide=True, wrap="word")
         self.txt_logs.grid(row=0, column=0, columnspan=2, sticky="nsew")
 
-        ttk.Label(self, text="Órdenes mínimas").grid(row=1, column=0, sticky="w")
-        ttk.Entry(self, textvariable=var_min_orders, width=10).grid(row=1, column=1, sticky="e")
+        ttk.Button(self, text="Limpiar log", command=self.clear_logs).grid(
+            row=1, column=0, sticky="ew", pady=(4, 0)
+        )
+        self.btn_pause = ttk.Button(self, text="Pausar log", command=self.toggle_pause)
+        self.btn_pause.grid(row=1, column=1, sticky="ew", pady=(4, 0))
+
+        ttk.Label(self, text="Órdenes mínimas").grid(row=2, column=0, sticky="w")
+        ttk.Entry(self, textvariable=var_min_orders, width=10).grid(row=2, column=1, sticky="e")
         ttk.Button(
             self,
             text="Aplicar mín. órdenes",
             command=on_apply_min_orders,
-        ).grid(row=2, column=0, columnspan=2, sticky="ew", pady=(4, 0))
+        ).grid(row=3, column=0, columnspan=2, sticky="ew", pady=(4, 0))
         ttk.Button(self, text="Revertir patch", command=on_revert_patch).grid(
-            row=3, column=0, sticky="ew", pady=(4, 0)
+            row=4, column=0, sticky="ew", pady=(4, 0)
         )
         ttk.Button(self, text="Aplicar a LIVE", command=on_apply_winner_live).grid(
-            row=3, column=1, sticky="ew", pady=(4, 0)
+            row=4, column=1, sticky="ew", pady=(4, 0)
         )
         ttk.Button(self, text="Crear PR patch", command=on_submit_patch).grid(
-            row=4, column=0, columnspan=2, sticky="ew", pady=(4, 0)
+            row=5, column=0, columnspan=2, sticky="ew", pady=(4, 0)
         )
 
         self.after(200, self._process_log_queue)
 
     # ------------------------------------------------------------------
-    def append_llm_log(self, tag: str, payload: Any) -> None:
+    def append_llm_log(
+        self, tag: str, payload: Any, label: Optional[str] = None
+    ) -> None:
         """Encola eventos del LLM para mostrarlos."""
-        text = clean_text(payload)
-        self._log_queue.put(f"[LLM {tag}] {text}")
+        text = sanitize_log(clean_text(payload))
+        if tag == "request":
+            self._log_queue.put(
+                lambda: self.render_llm_request(text, label)
+            )
+        elif tag == "response":
+            self._log_queue.put(lambda: self.render_llm_response(text))
+        else:
+            self._log_queue.put(
+                lambda: self._insert_text(f"[LLM {tag}] {text}")
+            )
+
+    def render_llm_request(self, text: str, label: Optional[str]) -> None:
+        msg = f'Envío LLM: Prompt "{label}"' if label else f"Envío LLM: {text}"
+        self._insert_text(msg)
+
+    def render_llm_response(self, text: str) -> None:
+        self._insert_text(f"Respuesta LLM: {text}")
+
+    def _insert_text(self, line: str) -> None:
+        self.txt_logs.insert("end", line + "\n")
+        self.txt_logs.see("end")
+
+    def clear_logs(self) -> None:
+        """Borra el contenido visible y la cola."""
+        self.txt_logs.delete("1.0", "end")
+        with self._log_queue.mutex:
+            self._log_queue.queue.clear()
+
+    def toggle_pause(self) -> None:
+        """Alterna el estado de pausa de los logs."""
+        self.paused = not self.paused
+        self.btn_pause.configure(
+            text="Reanudar log" if self.paused else "Pausar log"
+        )
 
     def _process_log_queue(self) -> None:
-        try:
-            while True:
-                line = self._log_queue.get_nowait()
-                self.txt_logs.insert("end", line + "\n")
-                self.txt_logs.see("end")
-        except queue.Empty:
-            pass
+        if not self.paused:
+            try:
+                while True:
+                    func = self._log_queue.get_nowait()
+                    func()
+            except queue.Empty:
+                pass
         self.after(200, self._process_log_queue)

--- a/components/testeos_frame.py
+++ b/components/testeos_frame.py
@@ -1,5 +1,6 @@
 from typing import Callable, Dict, Any
 from ttkbootstrap.constants import *
+from ttkbootstrap.scrolled import ScrolledFrame
 from tkinter import ttk
 import tkinter as tk
 
@@ -23,8 +24,8 @@ class TesteosFrame(ttk.Frame):
 
     def _build(self) -> None:
         """Construye los widgets principales."""
-        self.columnconfigure(0, weight=3)
-        self.columnconfigure(1, weight=2)
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=0)
         self.rowconfigure(0, weight=1)
 
         self.var_num_bots = tk.IntVar(value=10)
@@ -32,8 +33,8 @@ class TesteosFrame(ttk.Frame):
         self.var_depth_speed = tk.StringVar(value="100ms")
         self.var_mode = tk.StringVar(value="SIM")
 
-        # Tabla de bots fija
-        tbl_frame = ttk.Frame(self)
+        # Tabla de bots con scroll
+        tbl_frame = ScrolledFrame(self, autohide=True)
         tbl_frame.grid(row=0, column=0, sticky="nsew")
         tbl_frame.columnconfigure(0, weight=1)
         tbl_frame.rowconfigure(0, weight=1)
@@ -52,13 +53,15 @@ class TesteosFrame(ttk.Frame):
             self.tree.heading(col, text=txt)
             self.tree.column(col, width=width, anchor="center", stretch=True)
         vsb = ttk.Scrollbar(tbl_frame, orient="vertical", command=self.tree.yview)
-        self.tree.configure(yscrollcommand=vsb.set)
+        hsb = ttk.Scrollbar(tbl_frame, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
         self.tree.grid(row=0, column=0, sticky="nsew")
         vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
 
         # Panel lateral con controles e historial
         side = ttk.Frame(self, padding=(8, 0, 0, 0))
-        side.grid(row=0, column=1, sticky="nsew")
+        side.grid(row=0, column=1, sticky="ns")
         side.columnconfigure(0, weight=1)
         side.rowconfigure(3, weight=1)
 

--- a/llm/client.py
+++ b/llm/client.py
@@ -97,10 +97,10 @@ class LLMClient:
             return False
 
     # ------------------------------------------------------------------
-    def _log(self, tag: str, payload: Any) -> None:
+    def _log(self, tag: str, payload: Any, label: Optional[str] = None) -> None:
         if self.on_log:
             try:
-                self.on_log(tag, payload)
+                self.on_log(tag, payload, label)
             except Exception:
                 pass
 
@@ -136,14 +136,18 @@ class LLMClient:
         return None
 
     # ------------------------------------------------------------------
-    def _call_openai(self, trading_spec_text: str) -> List[Dict[str, object]]:
+    def _call_openai(
+        self, trading_spec_text: str, label: Optional[str] = None
+    ) -> List[Dict[str, object]]:
         assert self._client is not None
         messages = [
             {"role": "system", "content": PROMPT_P0},
             {"role": "system", "content": PROMPT_INICIAL_VARIACIONES},
             {"role": "user", "content": trading_spec_text},
         ]
-        self._log("request", {"model": self.model, "messages": messages})
+        self._log(
+            "request", {"model": self.model, "messages": messages}, label
+        )
         try:
             resp = self._client.chat.completions.create(
                 model=self.model,
@@ -199,7 +203,9 @@ class LLMClient:
         raw: List[Dict[str, object]] = []
         if self._client is not None and self.check_credentials():
             try:
-                raw = self._call_openai(trading_spec_text)
+                raw = self._call_openai(
+                    trading_spec_text, label="Variaciones Iniciales"
+                )
             except Exception:
                 raw = []
         if not raw:
@@ -297,7 +303,9 @@ class LLMClient:
                     "content": json.dumps({"history_fingerprints": history_fingerprints}),
                 },
             ]
-            self._log("request", {"model": self.model, "messages": messages})
+            self._log(
+                "request", {"model": self.model, "messages": messages}, label="Nueva Generación"
+            )
             try:
                 resp = self._client.chat.completions.create(
                     model=self.model,
@@ -364,7 +372,9 @@ class LLMClient:
                 {"role": "system", "content": PROMPT_ANALISIS_CICLO},
                 {"role": "user", "content": json.dumps(cycle_summary)},
             ]
-            self._log("request", {"model": self.model, "messages": messages})
+            self._log(
+                "request", {"model": self.model, "messages": messages}, label="Análisis de Ciclo"
+            )
             try:
                 resp = self._client.chat.completions.create(
                     model=self.model,
@@ -394,7 +404,9 @@ class LLMClient:
                 {"role": "system", "content": PROMPT_META_GANADOR},
                 {"role": "user", "content": json.dumps(winners)},
             ]
-            self._log("request", {"model": self.model, "messages": messages})
+            self._log(
+                "request", {"model": self.model, "messages": messages}, label="Meta-ganador"
+            )
             try:
                 resp = self._client.chat.completions.create(
                     model=self.model,
@@ -542,7 +554,9 @@ class LLMClient:
                 {"role": "system", "content": PROMPT_ANALISIS_GLOBAL},
                 {"role": "user", "content": json.dumps(summary)},
             ]
-            self._log("request", {"model": self.model, "messages": messages})
+            self._log(
+                "request", {"model": self.model, "messages": messages}, label="Análisis Global"
+            )
             try:
                 resp = self._client.chat.completions.create(
                     model=self.model,

--- a/tests/test_info_frame.py
+++ b/tests/test_info_frame.py
@@ -1,0 +1,47 @@
+import tkinter as tk
+
+from components.info_frame import InfoFrame
+
+
+def _dummy():
+    pass
+
+
+def test_logging_and_controls():
+    root = tk.Tk()
+    root.withdraw()
+
+    var = tk.IntVar()
+    frame = InfoFrame(root, var, _dummy, _dummy, _dummy, _dummy)
+
+    frame.append_llm_log(
+        "request", "hola,,, , ,", label="Variaciones Iniciales"
+    )
+    frame.append_llm_log(
+        "response", "respuesta,,, , , [], [], []"
+    )
+    frame.append_llm_log("request", "adhoc,,, , ,", label=None)
+    frame._process_log_queue()
+
+    text = frame.txt_logs.get("1.0", "end")
+    assert 'Envío LLM: Prompt "Variaciones Iniciales"' in text
+    assert 'Respuesta LLM:' in text
+    assert ', , ,' not in text
+    assert '[], [], []' not in text
+    assert 'Envío LLM: adhoc' in text
+
+    frame.toggle_pause()
+    frame.append_llm_log("response", "otra")
+    frame._process_log_queue()
+    assert text == frame.txt_logs.get("1.0", "end")
+
+    frame.toggle_pause()
+    frame.append_llm_log("response", "nuevo")
+    frame._process_log_queue()
+    assert 'nuevo' in frame.txt_logs.get("1.0", "end")
+
+    frame.clear_logs()
+    assert frame.txt_logs.get("1.0", "end").strip() == ""
+
+    root.destroy()
+

--- a/ui_app.py
+++ b/ui_app.py
@@ -83,7 +83,7 @@ class App(tb.Window):
     def __init__(self):
         super().__init__(title="AutoBTC - Punto a Punto", themename="cyborg")
         self.geometry("1400x860")
-        self.minsize(1300, 760)
+        self.minsize(900, 600)
 
         self.colors = UIColors()
         self.cfg = Defaults()
@@ -126,9 +126,9 @@ class App(tb.Window):
     # ------------------- UI -------------------
     def _build_ui(self):
         # Grid principal
-        self.columnconfigure(0, weight=3)
-        self.columnconfigure(1, weight=2)
-        self.rowconfigure(1, weight=2)
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.rowconfigure(1, weight=1)
         self.rowconfigure(2, weight=1)
         try:
             self._ensure_exchange()
@@ -161,19 +161,17 @@ class App(tb.Window):
         self.lbl_bal.grid(row=1, column=3, sticky="e", padx=5)
 
         # Panel fijo para testeos masivos
+        container = ttk.Frame(self, padding=(10, 0, 10, 8))
+        container.grid(row=1, column=0, columnspan=2, sticky="nsew")
+        container.columnconfigure(0, weight=1)
+        container.rowconfigure(0, weight=1)
+
         self.testeos_frame = TesteosFrame(
-            self,
+            container,
             self.on_toggle_mass_tests,
             self.on_load_winner_for_sim,
         )
-        self.testeos_frame.grid(
-            row=1,
-            column=0,
-            columnspan=2,
-            sticky="nsew",
-            padx=(10, 10),
-            pady=(0, 8),
-        )
+        self.testeos_frame.grid(row=0, column=0, sticky="nsew")
 
         # Panel inferior izquierdo para órdenes
         left = ttk.Frame(self, padding=(10,0,10,10))


### PR DESCRIPTION
## Summary
- sanitize and format LLM log entries with request/response helpers
- pass prompt labels from LLM client for clearer logging
- add Clear/Pause log buttons and tests for log formatting
- keep mass testing panel accessible with minimum window size and scrollable bot table

## Testing
- `xvfb-run -a pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1e0d450bc83289df7f1f6e4c7ba1c