### PR TITLE
feat: add cancel-replace monitoring

### DIFF
--- a/engine/strategy_base.py
+++ b/engine/strategy_base.py
@@ -1,12 +1,46 @@
 """Parameter driven implementation of the original BTC strategy."""
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+from dataclasses import dataclass
+from enum import Enum, auto
 from .strategy_params import Params
-from .ob_utils import book_hash, compute_imbalance, compute_spread_ticks
+from .ob_utils import (
+    book_hash,
+    compute_imbalance,
+    compute_spread_ticks,
+    try_fill_limit,
+    queue_ahead_qty,
+    estimate_fill_time,
+    best_price,
+)
 from exchange_utils.exchange_meta import exchange_meta
+from exchange_utils.orderbook_service import MarketDataHub
+
+
+class OrderLifecycle(Enum):
+    """Lifecycle states for a trade."""
+
+    SELECT_PAIR = auto()
+    PREP_BUY = auto()
+    SUBMIT_BUY = auto()
+    MONITOR_BUY = auto()
+    SUBMIT_SELL = auto()
+    MONITOR_SELL = auto()
+    DONE = auto()
+    ABORT = auto()
+
+
+@dataclass
+class OrderOutcome:
+    pnl: float = 0.0
+    pnl_pct: float = 0.0
+    slippage_ticks: int | None = None
+    expected_fill_time_s: float | None = None
+    actual_fill_time_s: float | None = None
 
 class StrategyBase:
     """Execute the base BTC strategy under mutable parameters."""
@@ -14,29 +48,446 @@ class StrategyBase:
     def __init__(self, exchange: Any) -> None:
         self.exchange = exchange
 
-    async def select_pairs(self, params: Params) -> List[str]:
-        """Return symbols that meet profitability and volume constraints."""
+    async def select_pairs(self, params: Params, hub: MarketDataHub) -> List[str]:
+        """Return BTC symbols that satisfy volume and fee constraints."""
         markets = await self.exchange.get_markets()
-        candidates: List[Tuple[str, float, float, float]] = []
+        candidates: List[Tuple[str, float, int, float, float]] = []
         for sym, info in markets.items():
             if not sym.endswith("BTC"):
                 continue
-            tick = float(info.get("price_increment", 1e-8))
-            fees = float(info.get("maker", 0.001)) + float(info.get("taker", 0.001))
-            ticker = await self.exchange.get_ticker(sym)
-            last = float(ticker.get("last", 0.0))
-            vol = float(ticker.get("base_volume", 0.0))
-            if vol < params.min_vol_btc_24h:
+            tick_data = hub.get_book_ticker(sym)
+            if not tick_data:
                 continue
+            filters = exchange_meta.price_filters(sym)
+            tick = float(filters.get("priceIncrement") or info.get("price_increment", 1e-8))
+            last = (
+                (tick_data.get("bid", 0.0) + tick_data.get("ask", 0.0)) / 2.0
+                if tick_data.get("bid") and tick_data.get("ask")
+                else tick_data.get("bid") or tick_data.get("ask") or 0.0
+            )
+            fees = float(info.get("maker", 0.001)) + float(info.get("taker", 0.001))
             fees_ticks = (last * fees) / tick if tick else 0.0
             if params.sell_k_ticks <= fees_ticks + params.commission_buffer_ticks:
                 continue
-            book = await self.exchange.get_order_book(sym)
-            spread = compute_spread_ticks(book, tick) if book else float("inf")
-            imbalance = compute_imbalance(book) if book else 0.0
-            candidates.append((sym, last, spread, imbalance))
-        candidates.sort(key=lambda x: (x[2], -x[3], x[1]))
+            try:
+                ticker = await self.exchange.get_ticker(sym)
+            except Exception:
+                continue
+            vol_btc = float(
+                ticker.get("quoteVolume")
+                or ticker.get("base_volume")
+                or ticker.get("baseVolume")
+                or 0.0
+            )
+            if vol_btc < params.min_vol_btc_24h:
+                continue
+            spread_ticks = (
+                int(round((tick_data.get("ask", 0.0) - tick_data.get("bid", 0.0)) / tick))
+                if tick
+                else 0
+            )
+            bid_qty = tick_data.get("bid_qty", 0.0)
+            ask_qty = tick_data.get("ask_qty", 0.0)
+            imbalance = (
+                (bid_qty / (bid_qty + ask_qty) * 100.0)
+                if (bid_qty + ask_qty) > 0
+                else 50.0
+            )
+            if imbalance < params.imbalance_buy_threshold_pct:
+                continue
+            latency_ms = (time.time() - tick_data.get("ts", time.time())) * 1000.0
+            candidates.append((sym, last, spread_ticks, imbalance, latency_ms))
+        candidates.sort(key=lambda x: (x[1], x[2], -x[3], x[4]))
         return [s for s, *_ in candidates]
+
+    async def prepare_buy(self, params: Params, symbol: str) -> Optional[Dict[str, Any]]:
+        """Prepare buy order parameters for ``symbol``."""
+
+        book = await self.exchange.get_order_book(symbol)
+        if not book:
+            return None
+        return await self.analyze_book(params, symbol, book, mode="LIVE")
+
+    async def submit_buy_live(self, symbol: str, price: float, qty: float) -> Dict[str, Any]:
+        from engine.trade_live import place_limit
+
+        return await asyncio.to_thread(place_limit, self.exchange, symbol, "buy", price, qty)
+
+    async def simulate_buy(self, book: Dict[str, Any], price: float, qty: float) -> Optional[Tuple[float, float]]:
+        filled, vwap = try_fill_limit(book, "buy", price, qty)
+        if filled < qty:
+            return None
+        return filled, vwap
+
+    async def monitor_buy_live(
+        self,
+        params: Params,
+        symbol: str,
+        order_id: str,
+        price: float,
+        qty: float,
+        tick: float,
+        hub: MarketDataHub,
+    ) -> Optional[Dict[str, Any]]:
+        """Monitor a live buy order applying cancel/replace rules."""
+
+        from engine.trade_live import cancel_replace, cancel_order, parse_fills
+
+        start = time.time()
+        moves = 0
+        filled = 0.0
+        avg_price = price
+        commission = 0.0
+        asset: Optional[str] = None
+        fills: List[Dict[str, float]] = []
+        events: List[Dict[str, Any]] = []
+        while True:
+            try:
+                order = await asyncio.to_thread(
+                    self.exchange.fetch_order, order_id, symbol
+                )
+            except Exception:
+                order = {}
+            fqty, favg, fee, asset, fdetail = parse_fills(order)
+            if fqty > filled:
+                filled = fqty
+                avg_price = favg or avg_price
+                commission += fee
+                fills = fdetail or fills
+                if filled < qty:
+                    events.append({
+                        "type": "partial_fill",
+                        "ts": time.time(),
+                        "filled_qty": filled,
+                    })
+            status = str(order.get("status", "")).upper()
+            if status == "FILLED" and filled >= qty:
+                return {
+                    "filled_qty": filled,
+                    "avg_price": avg_price,
+                    "commission_paid": commission,
+                    "commission_asset": asset,
+                    "cancel_replace_count": moves,
+                    "monitor_events": events,
+                    "actual_fill_time_s": time.time() - start,
+                    "order_id": order_id,
+                    "fills": fills,
+                }
+            if time.time() - start > params.max_wait_s:
+                if (
+                    params.cancel_replace_rules.enable
+                    and moves < params.cancel_replace_rules.max_moves
+                ):
+                    book = hub.get_order_book(symbol)
+                    best = best_price(book or {}, "buy") or price
+                    new_price = best + tick
+                    remaining = max(qty - filled, 0.0)
+                    try:
+                        _, new_order = await asyncio.to_thread(
+                            cancel_replace,
+                            self.exchange,
+                            symbol,
+                            order_id,
+                            "buy",
+                            new_price,
+                            remaining,
+                        )
+                        order_id = new_order.get("id", order_id)
+                        price = float(new_order.get("price", new_price))
+                        moves += 1
+                        events.append(
+                            {
+                                "type": "replace",
+                                "ts": time.time(),
+                                "new_price": price,
+                            }
+                        )
+                        start = time.time()
+                        continue
+                    except Exception:
+                        return None
+                try:
+                    await asyncio.to_thread(cancel_order, self.exchange, symbol, order_id)
+                except Exception:
+                    pass
+                events.append({"type": "timeout_cancel", "ts": time.time()})
+                return {
+                    "filled_qty": filled,
+                    "avg_price": avg_price,
+                    "commission_paid": commission,
+                    "commission_asset": asset,
+                    "cancel_replace_count": moves,
+                    "monitor_events": events,
+                    "actual_fill_time_s": time.time() - start,
+                    "order_id": order_id,
+                    "fills": fills,
+                    "aborted": True,
+                }
+            await asyncio.sleep(1)
+
+    async def monitor_buy_sim(
+        self,
+        params: Params,
+        symbol: str,
+        price: float,
+        qty: float,
+        tick: float,
+        hub: MarketDataHub,
+    ) -> Optional[Dict[str, Any]]:
+        """Simulate buy order monitoring with cancel/replace rules."""
+
+        start = time.time()
+        moves = 0
+        events: List[Dict[str, Any]] = []
+        filled = 0.0
+        avg_price = price
+        commission = 0.0
+        while True:
+            book = hub.get_order_book(symbol, top=100)
+            trade_rate = hub.get_trade_rate(symbol, price, "buy")
+            est = (
+                estimate_fill_time(book, "buy", price, qty - filled, trade_rate)
+                if book
+                else None
+            )
+            if est:
+                q_ahead, t_est = est
+                if t_est <= params.max_wait_s:
+                    filled_now, vwap = try_fill_limit(book, "buy", price, qty - filled)
+                    if filled_now > 0:
+                        filled += filled_now
+                        avg_price = vwap or avg_price
+                        commission = 0.0
+                        if filled < qty:
+                            events.append({"type": "partial_fill", "ts": time.time(), "filled_qty": filled})
+                    if filled >= qty:
+                        return {
+                            "filled_qty": filled,
+                            "avg_price": avg_price,
+                            "commission_paid": commission,
+                            "commission_asset": None,
+                            "cancel_replace_count": moves,
+                            "monitor_events": events,
+                            "actual_fill_time_s": time.time() - start,
+                            "order_id": None,
+                            "fills": [],
+                        }
+            if time.time() - start > params.max_wait_s:
+                if (
+                    params.cancel_replace_rules.enable
+                    and moves < params.cancel_replace_rules.max_moves
+                ):
+                    best = best_price(book or {}, "buy") or price
+                    price = best + tick
+                    moves += 1
+                    events.append({"type": "replace", "ts": time.time(), "new_price": price})
+                    start = time.time()
+                    continue
+                events.append({"type": "timeout_cancel", "ts": time.time()})
+                return {
+                    "filled_qty": filled,
+                    "avg_price": avg_price,
+                    "commission_paid": commission,
+                    "commission_asset": None,
+                    "cancel_replace_count": moves,
+                    "monitor_events": events,
+                    "actual_fill_time_s": time.time() - start,
+                    "order_id": None,
+                    "fills": [],
+                    "aborted": True,
+                }
+            await asyncio.sleep(1)
+
+    async def submit_sell_live(self, symbol: str, price: float, qty: float) -> Dict[str, Any]:
+        from engine.trade_live import place_limit
+
+        return await asyncio.to_thread(place_limit, self.exchange, symbol, "sell", price, qty)
+
+    async def simulate_sell(self, book: Dict[str, Any], price: float, qty: float) -> Optional[Tuple[float, float]]:
+        filled, vwap = try_fill_limit(book, "sell", price, qty)
+        if filled < qty:
+            return None
+        return filled, vwap
+
+    async def monitor_sell_live(
+        self,
+        params: Params,
+        symbol: str,
+        order_id: str,
+        price: float,
+        qty: float,
+        tick: float,
+        hub: MarketDataHub,
+        min_price: float,
+    ) -> Optional[Dict[str, Any]]:
+        """Monitor a live sell order applying cancel/replace rules."""
+
+        from engine.trade_live import cancel_replace, cancel_order, parse_fills
+
+        start = time.time()
+        moves = 0
+        filled = 0.0
+        avg_price = price
+        commission = 0.0
+        asset: Optional[str] = None
+        fills: List[Dict[str, float]] = []
+        events: List[Dict[str, Any]] = []
+        while True:
+            try:
+                order = await asyncio.to_thread(
+                    self.exchange.fetch_order, order_id, symbol
+                )
+            except Exception:
+                order = {}
+            fqty, favg, fee, asset, fdetail = parse_fills(order)
+            if fqty > filled:
+                filled = fqty
+                avg_price = favg or avg_price
+                commission += fee
+                fills = fdetail or fills
+                if filled < qty:
+                    events.append({
+                        "type": "partial_fill",
+                        "ts": time.time(),
+                        "filled_qty": filled,
+                    })
+            status = str(order.get("status", "")).upper()
+            if status == "FILLED" and filled >= qty:
+                return {
+                    "filled_qty": filled,
+                    "avg_price": avg_price,
+                    "commission_paid": commission,
+                    "commission_asset": asset,
+                    "cancel_replace_count": moves,
+                    "monitor_events": events,
+                    "actual_fill_time_s": time.time() - start,
+                    "order_id": order_id,
+                    "fills": fills,
+                }
+            if time.time() - start > params.max_wait_s:
+                if (
+                    params.cancel_replace_rules.enable
+                    and moves < params.cancel_replace_rules.max_moves
+                ):
+                    book = hub.get_order_book(symbol)
+                    best = best_price(book or {}, "sell") or price
+                    new_price = max(best - tick, min_price)
+                    remaining = max(qty - filled, 0.0)
+                    try:
+                        _, new_order = await asyncio.to_thread(
+                            cancel_replace,
+                            self.exchange,
+                            symbol,
+                            order_id,
+                            "sell",
+                            new_price,
+                            remaining,
+                        )
+                        order_id = new_order.get("id", order_id)
+                        price = float(new_order.get("price", new_price))
+                        moves += 1
+                        events.append(
+                            {
+                                "type": "replace",
+                                "ts": time.time(),
+                                "new_price": price,
+                            }
+                        )
+                        start = time.time()
+                        continue
+                    except Exception:
+                        return None
+                try:
+                    await asyncio.to_thread(cancel_order, self.exchange, symbol, order_id)
+                except Exception:
+                    pass
+                events.append({"type": "timeout_cancel", "ts": time.time()})
+                return {
+                    "filled_qty": filled,
+                    "avg_price": avg_price,
+                    "commission_paid": commission,
+                    "commission_asset": asset,
+                    "cancel_replace_count": moves,
+                    "monitor_events": events,
+                    "actual_fill_time_s": time.time() - start,
+                    "order_id": order_id,
+                    "fills": fills,
+                    "aborted": True,
+                }
+            await asyncio.sleep(1)
+
+    async def monitor_sell_sim(
+        self,
+        params: Params,
+        symbol: str,
+        price: float,
+        qty: float,
+        tick: float,
+        hub: MarketDataHub,
+        min_price: float,
+    ) -> Optional[Dict[str, Any]]:
+        """Simulate sell order monitoring with cancel/replace rules."""
+
+        start = time.time()
+        moves = 0
+        events: List[Dict[str, Any]] = []
+        filled = 0.0
+        avg_price = price
+        commission = 0.0
+        while True:
+            book = hub.get_order_book(symbol, top=100)
+            trade_rate = hub.get_trade_rate(symbol, price, "sell")
+            est = (
+                estimate_fill_time(book, "sell", price, qty - filled, trade_rate)
+                if book
+                else None
+            )
+            if est:
+                q_ahead, t_est = est
+                if t_est <= params.max_wait_s:
+                    filled_now, vwap = try_fill_limit(book, "sell", price, qty - filled)
+                    if filled_now > 0:
+                        filled += filled_now
+                        avg_price = vwap or avg_price
+                        if filled < qty:
+                            events.append({"type": "partial_fill", "ts": time.time(), "filled_qty": filled})
+                    if filled >= qty:
+                        return {
+                            "filled_qty": filled,
+                            "avg_price": avg_price,
+                            "commission_paid": commission,
+                            "commission_asset": None,
+                            "cancel_replace_count": moves,
+                            "monitor_events": events,
+                            "actual_fill_time_s": time.time() - start,
+                            "order_id": None,
+                            "fills": [],
+                        }
+            if time.time() - start > params.max_wait_s:
+                if (
+                    params.cancel_replace_rules.enable
+                    and moves < params.cancel_replace_rules.max_moves
+                ):
+                    best = best_price(book or {}, "sell") or price
+                    price = max(best - tick, min_price)
+                    moves += 1
+                    events.append({"type": "replace", "ts": time.time(), "new_price": price})
+                    start = time.time()
+                    continue
+                events.append({"type": "timeout_cancel", "ts": time.time()})
+                return {
+                    "filled_qty": filled,
+                    "avg_price": avg_price,
+                    "commission_paid": commission,
+                    "commission_asset": None,
+                    "cancel_replace_count": moves,
+                    "monitor_events": events,
+                    "actual_fill_time_s": time.time() - start,
+                    "order_id": None,
+                    "fills": [],
+                    "aborted": True,
+                }
+            await asyncio.sleep(1)
 
     async def analyze_book(
         self, params: Params, symbol: str, book: Dict[str, Any], mode: str = "SIM"

--- a/exchange_utils/exchange_meta.py
+++ b/exchange_utils/exchange_meta.py
@@ -95,4 +95,10 @@ class ExchangeMeta:
             raise ValueError("notional below minNotional")
         return price, qty, filters
 
+    # Convenience helper -------------------------------------------------
+    def price_filters(self, symbol: str) -> Dict[str, Any]:
+        """Expose cached filters for external modules."""
+
+        return self.get_symbol_filters(symbol)
+
 exchange_meta = ExchangeMeta()

--- a/orchestrator/runner.py
+++ b/orchestrator/runner.py
@@ -7,10 +7,10 @@ import time
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
-from .models import BotConfig, BotStats
+from .models import BotConfig, BotStats, SupervisorEvent
 from engine.strategy_base import StrategyBase
 from engine.strategy_params import Params, map_mutations_to_params
-from engine.ob_utils import estimate_fill_time
+from engine.ob_utils import estimate_fill_time, try_fill_limit
 from exchange_utils.orderbook_service import MarketDataHub, market_data_hub
 from data_logger import log_event
 
@@ -39,6 +39,28 @@ class BotRunner:
         self.hub = hub
         self.mode = mode.upper()
 
+    def _emit(
+        self,
+        level: str,
+        message: str,
+        payload: Optional[Dict[str, Any]] = None,
+        ts: Optional[float] = None,
+    ) -> None:
+        event = SupervisorEvent(
+            ts=datetime.utcfromtimestamp(ts) if ts else datetime.utcnow(),
+            level=level,
+            scope="bot",
+            cycle=self.config.cycle,
+            bot_id=self.config.id,
+            message=message,
+            payload=payload,
+        )
+        try:
+            self.storage.append_event(event)
+        except Exception:
+            pass
+        log_event({"event": message, "bot_id": self.config.id, "cycle_id": self.config.cycle, **(payload or {})})
+
     async def run(self) -> BotStats:
         """Execute the bot respecting the provided limits."""
         params: Params = map_mutations_to_params(self.config.mutations)
@@ -47,6 +69,10 @@ class BotRunner:
         wins = 0
         losses = 0
         pnl = 0.0
+        hold_times: List[float] = []
+        slippage_total = 0
+        timeouts = 0
+        trades = 0
 
         max_orders = self.limits.get("max_orders", float("inf"))
         max_scans = self.limits.get("max_scans", 1)
@@ -59,7 +85,7 @@ class BotRunner:
             and time.time() - start < max_runtime
         ):
             scans += 1
-            symbols = await self.strategy.select_pairs(params)
+            symbols = await self.strategy.select_pairs(params, self.hub)
             for sym in symbols:
                 if (
                     orders_count >= max_orders
@@ -82,9 +108,12 @@ class BotRunner:
                 if not buy_data:
                     continue
 
+                phase_ts = {"SELECT_PAIR": datetime.utcnow().isoformat()}
+                self._emit("INFO", "pair_selected", {"symbol": sym, "data": buy_data})
                 amount = buy_data["amount"]
                 tick = buy_data["tick_size"]
                 buy_price = buy_data["price"]
+                phase_ts["PREP_BUY"] = datetime.utcnow().isoformat()
 
                 # Estimate fill time before placing the buy order
                 book_full = self.hub.get_order_book(sym, top=100)
@@ -103,74 +132,94 @@ class BotRunner:
                     "trade_rate_qty_per_s": trade_rate,
                 }
 
-                # Log pair selection after preliminary checks pass
-                log_event(
+                if self.mode == "LIVE":
+                    try:
+                        order = await self.strategy.submit_buy_live(sym, buy_price, amount)
+                    except Exception:
+                        self._emit("ERROR", "buy_submit_failed", {"symbol": sym})
+                        continue
+                    phase_ts["SUBMIT_BUY"] = datetime.utcnow().isoformat()
+                    self._emit(
+                        "INFO",
+                        "buy_submitted",
+                        {
+                            "symbol": sym,
+                            "price": buy_price,
+                            "qty": amount,
+                            "exchange_order_id": order.get("id"),
+                        },
+                    )
+                    res = await self.strategy.monitor_buy_live(
+                        params, sym, order.get("id"), buy_price, amount, tick, self.hub
+                    )
+                else:
+                    phase_ts["SUBMIT_BUY"] = datetime.utcnow().isoformat()
+                    self._emit(
+                        "INFO",
+                        "buy_submitted",
+                        {"symbol": sym, "price": buy_price, "qty": amount},
+                    )
+                    if hasattr(self.strategy, "monitor_buy_sim"):
+                        res = await self.strategy.monitor_buy_sim(
+                            params, sym, buy_price, amount, tick, self.hub
+                        )
+                    else:
+                        res = {
+                            "filled_qty": amount,
+                            "avg_price": buy_price,
+                            "commission_paid": 0.0,
+                            "commission_asset": None,
+                            "cancel_replace_count": 0,
+                            "monitor_events": [],
+                            "actual_fill_time_s": t_est,
+                            "order_id": None,
+                            "fills": [],
+                        }
+                phase_ts["MONITOR_BUY"] = datetime.utcnow().isoformat()
+                if not res or res.get("aborted") or res.get("filled_qty", 0) < amount:
+                    reason_codes = [e.get("type") for e in (res or {}).get("monitor_events", [])]
+                    if "timeout_cancel" in reason_codes:
+                        timeouts += 1
+                    phase_ts["ABORT"] = datetime.utcnow().isoformat()
+                    self._emit(
+                        "WARNING",
+                        "buy_aborted",
+                        {"symbol": sym, "reason_codes": reason_codes},
+                    )
+                    continue
+                for ev in res.get("monitor_events", []):
+                    self._emit(
+                        "INFO",
+                        f"buy_{ev['type']}",
+                        {"symbol": sym, **{k: v for k, v in ev.items() if k != 'type'}},
+                        ts=ev.get("ts"),
+                    )
+                buy_vwap = res["avg_price"]
+                amount = res["filled_qty"]
+                reason_codes = [e.get("type") for e in res.get("monitor_events", [])]
+                buy_metrics.update(
                     {
-                        "event": "pair_selected",
-                        "bot_id": self.config.id,
-                        "cycle_id": self.config.cycle,
-                        "symbol": sym,
-                        "data": buy_data,
+                        "actual_fill_time_s": res.get("actual_fill_time_s"),
+                        "monitor_events": res.get("monitor_events"),
+                        "commission_paid": res.get("commission_paid"),
+                        "commission_asset": res.get("commission_asset"),
+                        "cancel_replace_count": res.get("cancel_replace_count"),
+                        "exchange_order_id": res.get("order_id"),
+                        "fills": res.get("fills"),
+                        "reason_codes": reason_codes,
                     }
                 )
-
-                buy_vwap = None
-
-                if self.mode == "LIVE":
-                    from engine.trade_live import (
-                        place_limit,
-                        fetch_order_status,
-                        cancel_order,
-                    )
-
-                    try:
-                        t0 = time.time()
-                        order = await asyncio.to_thread(
-                            place_limit, self.exchange, sym, "buy", buy_price, amount
-                        )
-                        oid = order.get("id")
-                        order = await asyncio.to_thread(
-                            fetch_order_status,
-                            self.exchange,
-                            sym,
-                            oid,
-                            params.max_wait_s,
-                        )
-                        buy_metrics["actual_fill_time_s"] = time.time() - t0
-                    except Exception:
-                        if "oid" in locals():
-                            try:
-                                await asyncio.to_thread(cancel_order, self.exchange, sym, oid)
-                            except Exception:
-                                pass
-                        continue
-                    filled = float(order.get("filled") or order.get("executedQty") or 0.0)
-                    buy_vwap = float(order.get("average") or order.get("price") or 0.0)
-                    if filled < amount:
-                        try:
-                            await asyncio.to_thread(cancel_order, self.exchange, sym, oid)
-                        except Exception:
-                            pass
-                        continue
-                    buy_price = float(order.get("price", buy_price))
-                else:
-                    buy_vwap = buy_price
-                    buy_metrics["actual_fill_time_s"] = t_est
-
-                log_event(
-                    {
-                        "event": "buy_order",
-                        "bot_id": self.config.id,
-                        "cycle_id": self.config.cycle,
-                        "symbol": sym,
-                        "price": buy_price,
-                        "qty": amount,
-                        "metrics": buy_metrics,
-                    }
+                buy_slip = int(round((buy_vwap - buy_price) / tick))
+                buy_metrics["slippage_ticks"] = buy_slip
+                buy_metrics["phase_timestamps"] = phase_ts
+                self._emit(
+                    "INFO",
+                    "buy_filled",
+                    {"symbol": sym, "price": buy_price, "vwap": buy_vwap, "qty": amount},
                 )
 
                 sell_order = self.strategy.build_sell_order(
-                    params, {**buy_data, "price": buy_price}, mode=self.mode
+                    params, {**buy_data, "price": buy_price, "amount": amount}, mode=self.mode
                 )
                 sell_price = sell_order["price"]
 
@@ -190,63 +239,111 @@ class BotRunner:
                     "queue_ahead_qty": queue_qty2,
                     "trade_rate_qty_per_s": trade_rate2,
                 }
-                sell_vwap = None
-
                 if self.mode == "LIVE":
                     try:
-                        t1 = time.time()
-                        sorder = await asyncio.to_thread(
-                            place_limit, self.exchange, sym, "sell", sell_price, amount
-                        )
-                        soid = sorder.get("id")
-                        sorder = await asyncio.to_thread(
-                            fetch_order_status,
-                            self.exchange,
-                            sym,
-                            soid,
-                            params.max_wait_s,
-                        )
-                        sell_metrics["actual_fill_time_s"] = time.time() - t1
+                        sorder = await self.strategy.submit_sell_live(sym, sell_price, amount)
                     except Exception:
-                        if "soid" in locals():
-                            try:
-                                await asyncio.to_thread(
-                                    cancel_order, self.exchange, sym, soid
-                                )
-                            except Exception:
-                                pass
+                        self._emit("ERROR", "sell_submit_failed", {"symbol": sym})
                         continue
-                    filled = float(sorder.get("filled") or sorder.get("executedQty") or 0.0)
-                    sell_vwap = float(sorder.get("average") or sorder.get("price") or 0.0)
-                    if filled < amount:
-                        try:
-                            await asyncio.to_thread(
-                                cancel_order, self.exchange, sym, soid
-                            )
-                        except Exception:
-                            pass
-                        continue
-                    sell_price = float(sorder.get("price", sell_price))
+                    phase_ts["SUBMIT_SELL"] = datetime.utcnow().isoformat()
+                    self._emit(
+                        "INFO",
+                        "sell_submitted",
+                        {
+                            "symbol": sym,
+                            "price": sell_price,
+                            "qty": amount,
+                            "exchange_order_id": sorder.get("id"),
+                        },
+                    )
+                    res = await self.strategy.monitor_sell_live(
+                        params,
+                        sym,
+                        sorder.get("id"),
+                        sell_price,
+                        amount,
+                        tick,
+                        self.hub,
+                        buy_vwap + tick * params.commission_buffer_ticks,
+                    )
                 else:
-                    sell_vwap = sell_price
-                    sell_metrics["actual_fill_time_s"] = t_est2
-
-                log_event(
+                    phase_ts["SUBMIT_SELL"] = datetime.utcnow().isoformat()
+                    self._emit(
+                        "INFO",
+                        "sell_submitted",
+                        {"symbol": sym, "price": sell_price, "qty": amount},
+                    )
+                    if hasattr(self.strategy, "monitor_sell_sim"):
+                        res = await self.strategy.monitor_sell_sim(
+                            params,
+                            sym,
+                            sell_price,
+                            amount,
+                            tick,
+                            self.hub,
+                            buy_vwap + tick * params.commission_buffer_ticks,
+                        )
+                    else:
+                        res = {
+                            "filled_qty": amount,
+                            "avg_price": sell_price,
+                            "commission_paid": 0.0,
+                            "commission_asset": None,
+                            "cancel_replace_count": 0,
+                            "monitor_events": [],
+                            "actual_fill_time_s": t_est2,
+                            "order_id": None,
+                            "fills": [],
+                        }
+                phase_ts["MONITOR_SELL"] = datetime.utcnow().isoformat()
+                if not res or res.get("aborted") or res.get("filled_qty", 0) < amount:
+                    reason_codes = [e.get("type") for e in (res or {}).get("monitor_events", [])]
+                    if "timeout_cancel" in reason_codes:
+                        timeouts += 1
+                    phase_ts["ABORT"] = datetime.utcnow().isoformat()
+                    self._emit(
+                        "WARNING",
+                        "sell_aborted",
+                        {"symbol": sym, "reason_codes": reason_codes},
+                    )
+                    continue
+                for ev in res.get("monitor_events", []):
+                    self._emit(
+                        "INFO",
+                        f"sell_{ev['type']}",
+                        {"symbol": sym, **{k: v for k, v in ev.items() if k != 'type'}},
+                        ts=ev.get("ts"),
+                    )
+                sell_vwap = res["avg_price"]
+                reason_codes_sell = [e.get("type") for e in res.get("monitor_events", [])]
+                sell_metrics.update(
                     {
-                        "event": "sell_order",
-                        "bot_id": self.config.id,
-                        "cycle_id": self.config.cycle,
-                        "symbol": sym,
-                        "price": sell_price,
-                        "qty": amount,
-                        "metrics": sell_metrics,
+                        "actual_fill_time_s": res.get("actual_fill_time_s"),
+                        "monitor_events": res.get("monitor_events"),
+                        "commission_paid": res.get("commission_paid"),
+                        "commission_asset": res.get("commission_asset"),
+                        "cancel_replace_count": res.get("cancel_replace_count"),
+                        "exchange_order_id": res.get("order_id"),
+                        "fills": res.get("fills"),
+                        "reason_codes": reason_codes_sell,
+                        "phase_timestamps": phase_ts,
                     }
                 )
+                sell_slip = int(round((sell_vwap - sell_price) / tick))
+                sell_metrics["slippage_ticks"] = sell_slip
+                self._emit(
+                    "INFO",
+                    "sell_filled",
+                    {"symbol": sym, "price": sell_price, "vwap": sell_vwap, "qty": amount},
+                )
 
-                hold_time = (buy_metrics or {}).get("actual_fill_time_s", 0.0) + (
-                    sell_metrics or {}
-                ).get("actual_fill_time_s", 0.0)
-                profit = (sell_vwap - buy_vwap) * amount
+                hold_time = (
+                    (buy_metrics or {}).get("actual_fill_time_s", 0.0)
+                    + (sell_metrics or {}).get("actual_fill_time_s", 0.0)
+                )
+                cost = buy_vwap * amount + (buy_metrics.get("commission_paid") or 0.0)
+                revenue = sell_vwap * amount - (sell_metrics.get("commission_paid") or 0.0)
+                profit = revenue - cost
                 pnl += profit
                 if profit >= 0:
                     wins += 1
@@ -271,8 +368,8 @@ class BotRunner:
                     "qty": amount,
                     "price": buy_price,
                     "resulting_fill_price": buy_vwap,
-                    "fee_asset": None,
-                    "fee_amount": None,
+                    "fee_asset": buy_metrics.get("commission_asset"),
+                    "fee_amount": buy_metrics.get("commission_paid"),
                     "ts": datetime.utcnow().isoformat(),
                     "status": "filled",
                     "pnl": None,
@@ -284,13 +381,14 @@ class BotRunner:
                     "top3_depth": top3_json,
                     "book_hash": buy_data.get("book_hash"),
                     "latency_ms": buy_data.get("latency_ms"),
-                    "cancel_replace_count": 0,
+                    "cancel_replace_count": buy_metrics.get("cancel_replace_count", 0),
                     "time_in_force": None,
                     "hold_time_s": None,
                     "raw_json": json.dumps(
                         {
                             "price": buy_price,
                             "amount": amount,
+                            "book_hash": buy_data.get("book_hash"),
                             **(buy_metrics or {}),
                         }
                     ),
@@ -305,8 +403,8 @@ class BotRunner:
                     "qty": amount,
                     "price": sell_price,
                     "resulting_fill_price": sell_vwap,
-                    "fee_asset": None,
-                    "fee_amount": None,
+                    "fee_asset": sell_metrics.get("commission_asset"),
+                    "fee_amount": sell_metrics.get("commission_paid"),
                     "ts": datetime.utcnow().isoformat(),
                     "status": "filled",
                     "pnl": profit,
@@ -318,13 +416,14 @@ class BotRunner:
                     "top3_depth": None,
                     "book_hash": None,
                     "latency_ms": None,
-                    "cancel_replace_count": 0,
+                    "cancel_replace_count": sell_metrics.get("cancel_replace_count", 0),
                     "time_in_force": None,
                     "hold_time_s": hold_time,
                     "raw_json": json.dumps(
                         {
                             "price": sell_price,
                             "amount": amount,
+                            "book_hash": buy_data.get("book_hash"),
                             **(sell_metrics or {}),
                         }
                     ),
@@ -332,15 +431,11 @@ class BotRunner:
 
                 self.storage.save_order(buy_record)
                 self.storage.save_order(sell_record)
-                log_event(
-                    {
-                        "event": "order_complete",
-                        "bot_id": self.config.id,
-                        "cycle_id": self.config.cycle,
-                        "symbol": sym,
-                        "profit": profit,
-                        "hold_time_s": hold_time,
-                    }
+                phase_ts["DONE"] = datetime.utcnow().isoformat()
+                self._emit(
+                    "INFO",
+                    "order_complete",
+                    {"symbol": sym, "profit": profit, "hold_time_s": hold_time},
                 )
                 self.ui_callback(
                     {
@@ -351,12 +446,29 @@ class BotRunner:
                     }
                 )
                 orders_count += 2
+                hold_times.append(hold_time)
+                slippage_total += abs(buy_slip) + abs(sell_slip)
+                trades += 1
 
             await asyncio.sleep(0)
 
         runtime_s = int(time.time() - start)
         notional_total = params.order_size_usd * (orders_count / 2)
         pnl_pct_total = (pnl / notional_total * 100.0) if notional_total else 0.0
+        avg_hold = sum(hold_times) / len(hold_times) if hold_times else 0.0
+        avg_slip = slippage_total / (2 * trades) if trades else 0.0
+        win_rate = wins / (wins + losses) if (wins + losses) else 0.0
+        self._emit(
+            "INFO",
+            "bot_summary",
+            {
+                "orders": orders_count,
+                "win_rate": win_rate,
+                "avg_hold_s": avg_hold,
+                "avg_slippage_ticks": avg_slip,
+                "timeouts": timeouts,
+            },
+        )
         stats = BotStats(
             bot_id=self.config.id,
             cycle=self.config.cycle,

--- a/orchestrator/storage.py
+++ b/orchestrator/storage.py
@@ -282,7 +282,7 @@ class SQLiteStorage:
         "pnl",
         "pnl_pct",
         "notes",
-        "raw_json",
+        "raw_json",  # JSON blob with extended metrics
         "expected_profit_ticks",
         "actual_profit_ticks",
         "spread_ticks",

--- a/orchestrator/supervisor.py
+++ b/orchestrator/supervisor.py
@@ -203,13 +203,11 @@ class Supervisor:
 
     def _global_loop(self) -> None:
         while self._global_stop and not self._global_stop.is_set():
-            time.sleep(self._global_interval_s)
-            if self._global_stop and self._global_stop.is_set():
-                break
             try:
                 self.run_global_analysis()
             except Exception as e:
                 self._emit("ERROR", "llm", None, None, "global_analysis_fail", {"error": str(e)})
+            time.sleep(self._global_interval_s)
 
     def run_global_analysis(self) -> None:
         summary = self.storage.gather_global_summary()


### PR DESCRIPTION
## Summary
- capture detailed exchange fills including per-fill fees and assets
- track partial fills, replacements, and cancellations across buy/sell monitors
- emit structured events for each trade phase and persist full lifecycle metrics in order logs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2318d727c83288e705579b8dd7f8c