### PR TITLE
Handle pair lifecycle with retries and completion event

### DIFF
--- a/tests/test_operation_logging.py
+++ b/tests/test_operation_logging.py
@@ -73,6 +73,7 @@ def test_operation_logging(tmp_path, monkeypatch):
         "sell_submitted",
         "sell_filled",
         "order_complete",
+        "pair_completed",
         "bot_summary",
     ]
     for e in events:
@@ -82,7 +83,7 @@ def test_operation_logging(tmp_path, monkeypatch):
 
     storage = SQLiteStorage(db_path=str(db))
     db_events = storage.get_events()
-    assert [ev.message for ev in db_events][-2:] == ["order_complete", "bot_summary"]
+    assert [ev.message for ev in db_events][-2:] == ["pair_completed", "bot_summary"]
 
     summary = storage.build_llm_cycle_summary(1)
     assert summary["cycle"] == 1


### PR DESCRIPTION
## Summary
- track buys and sells separately and retry orders until fills, halting new buys until prior sell completes
- emit `pair_completed` after each buy/sell cycle and include buy/sell counts in bot summary
- simulate fills using order book data and close cycles on sell fills only in legacy engine

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2497470308328a1584fa65b44fa50