### PR TITLE
Track buy/sell stats for bots and enforce minimum buys

### DIFF
--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -25,6 +25,8 @@ class BotStats:
     bot_id: int
     cycle: int
     orders: int
+    buys: int
+    sells: int
     pnl: float
     pnl_pct: float
     runtime_s: int

--- a/orchestrator/runner.py
+++ b/orchestrator/runner.py
@@ -354,10 +354,20 @@ class BotRunner:
                 "timeouts": timeouts,
             },
         )
+
+        min_buys = self.limits.get("min_buys")
+        if min_buys is not None and buy_count < int(min_buys):
+            self._emit(
+                "WARNING",
+                "min_buys_not_reached",
+                {"buys": buy_count, "min_buys": int(min_buys)},
+            )
         stats = BotStats(
             bot_id=self.config.id,
             cycle=self.config.cycle,
             orders=orders_count,
+            buys=buy_count,
+            sells=sell_count,
             pnl=pnl,
             pnl_pct=pnl_pct_total,
             runtime_s=runtime_s,

--- a/schema.sql
+++ b/schema.sql
@@ -19,6 +19,8 @@ CREATE TABLE IF NOT EXISTS bot_stats (
     bot_id INTEGER,
     cycle_id INTEGER,
     orders INTEGER,
+    buys INTEGER,
+    sells INTEGER,
     pnl REAL,
     pnl_pct REAL,
     runtime_s INTEGER,


### PR DESCRIPTION
## Summary
- Track buys and sells per bot and persist them to SQLite
- Warn when a bot finishes with fewer buys than required
- Treat min orders as min buys and double to derive max orders for runners

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a24f5ecb4c8328897f2c843aa53af8