### PR TITLE
Improve engine logging and UI log formatting

### DIFF
--- a/engine/legacy.py
+++ b/engine/legacy.py
@@ -49,6 +49,7 @@ class Engine(threading.Thread):
 
     def stop(self):
         """Señala al hilo que debe detenerse."""
+        self.ui_log(f"[WARN] [ENGINE {self.name}] Stop solicitado")
         self._stop_event.set()
 
     def is_stopped(self) -> bool:
@@ -191,7 +192,7 @@ class Engine(threading.Thread):
                 "FILL", sym, f"BUY {qty_usd:.2f} USD @ {fill_price} ({order.get('mode')})"
             )
             self.ui_log(
-                f"[ENGINE {self.name}] FILL BUY {sym} {qty_usd:.2f} @ {fill_price}"
+                f"[INFO] [ENGINE {self.name}] FILL BUY {sym} {qty_usd:.2f} @ {fill_price}"
             )
         else:
             pos["qty"] = pos["qty"] - qty_base
@@ -215,7 +216,7 @@ class Engine(threading.Thread):
                 "FILL", sym, f"SELL {qty_usd:.2f} USD @ {fill_price} ({order.get('mode')})"
             )
             self.ui_log(
-                f"[ENGINE {self.name}] FILL SELL {sym} {qty_usd:.2f} @ {fill_price}"
+                f"[INFO] [ENGINE {self.name}] FILL SELL {sym} {qty_usd:.2f} @ {fill_price} PNL {pnl:.2f}"
             )
             try:
                 self.order_hook(trade)
@@ -549,6 +550,7 @@ def _log_audit(self, event: str, sym: str, detail: str):
         return True
 
     def run(self):
+        self.ui_log(f"[INFO] [ENGINE {self.name}] Hilo iniciado")
         try:
             greet_msg = self.llm.greet("hola")
             if greet_msg:
@@ -653,6 +655,7 @@ def _log_audit(self, event: str, sym: str, detail: str):
 
             time.sleep(0.25)
 
+        self.ui_log(f"[INFO] [ENGINE {self.name}] Hilo detenido")
 
     def _ensure_logs_dir(self):
         import os

--- a/ui_app.py
+++ b/ui_app.py
@@ -692,12 +692,23 @@ class App(tb.Window):
         self.log_append(f"[ORDER {mode}] {side} {sym} {qty} @ {price}")
 
     def log_append(self, msg: str):
+        """Append log messages to the UI log with timestamp and level."""
+        level = "INFO"
+        for prefix in ("[ERROR]", "[WARN]", "[INFO]"):
+            if msg.startswith(prefix):
+                level = prefix[1:-1]
+                msg = msg[len(prefix):].strip()
+                break
+
         if msg.startswith("[LLM]"):
             self.info_frame.append_llm_log("info", msg[5:].strip())
-        else:
-            if not hasattr(self, "_log_queue"):
-                self._log_queue = queue.Queue()
-            self._log_queue.put(clean_text(msg))
+
+        if not hasattr(self, "_log_queue"):
+            self._log_queue = queue.Queue()
+
+        ts = time.strftime("%H:%M:%S")
+        formatted = f"{ts} [{level}] {clean_text(msg)}"
+        self._log_queue.put(formatted)
 
     def _poll_log_queue(self):
         try:


### PR DESCRIPTION
## Summary
- Display all log events in UI with timestamp and level
- Log engine start/stop and fills via `ui_log`
- Record stop requests through `ui_log`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2559ebdf0832896c88679a927da19