### PR TITLE
Handle YAML-formatted LLM responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy>=1.25
 matplotlib>=3.8
 
 openai>=1.40.0
+pyyaml>=6.0

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -29,6 +29,29 @@ def test_generate_initial_variations_extracts_json(monkeypatch):
     assert res[0]["name"] == "foo"
     assert len(res) == 10
 
+
+def test_generate_initial_variations_parses_yaml(monkeypatch):
+    content = "bots:\n  - name: foo\n    mutations: {}\n"
+    client = LLMClient(api_key="")
+    client._client = DummyClient(content)
+    monkeypatch.setattr(LLMClient, "check_credentials", lambda self: True)
+    res = client.generate_initial_variations("spec")
+    assert res[0]["name"] == "foo"
+    assert len(res) == 10
+
+
+def test_generate_initial_variations_handles_trailing_commas_and_alias(monkeypatch):
+    content = (
+        "bots:\n  - name: bot_1,\n    mutation:\n      order_size_usd: 12.7,\n"
+    )
+    client = LLMClient(api_key="")
+    client._client = DummyClient(content)
+    monkeypatch.setattr(LLMClient, "check_credentials", lambda self: True)
+    res = client.generate_initial_variations("spec")
+    assert res[0]["name"] == "bot_1"
+    assert res[0]["mutations"]["order_size_usd"] == 12.7
+    assert len(res) == 10
+
 def test_analyze_cycle_extracts_json_from_code_block():
     content = "```json\n{\"winner_bot_id\": 7, \"reason\": \"ok\"}\n```"
     client = LLMClient(api_key="")
@@ -43,6 +66,27 @@ def test_new_generation_extracts_json_from_code_block():
     client._client = DummyClient(content)
     res = client.new_generation_from_winner({}, [])
     assert res[0]["name"] == "foo"
+    assert len(res) == 10
+
+
+def test_new_generation_parses_yaml():
+    content = "bots:\n  - name: foo\n    mutations: {}\n"
+    client = LLMClient(api_key="")
+    client._client = DummyClient(content)
+    res = client.new_generation_from_winner({}, [])
+    assert res[0]["name"] == "foo"
+    assert len(res) == 10
+
+
+def test_new_generation_handles_trailing_commas_and_alias():
+    content = (
+        "bots:\n  - name: bot_1,\n    mutation:\n      order_size_usd: 12.7,\n"
+    )
+    client = LLMClient(api_key="")
+    client._client = DummyClient(content)
+    res = client.new_generation_from_winner({}, [])
+    assert res[0]["name"] == "bot_1"
+    assert res[0]["mutations"]["order_size_usd"] == 12.7
     assert len(res) == 10
 
 


### PR DESCRIPTION
## Summary
- sanitize LLM YAML output by stripping trailing commas and parsing it safely
- accept both `mutations` and `mutation` keys when building bot variation lists
- test YAML parsing with trailing commas and singular mutation key

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a267f783708328a1adc44583023b06